### PR TITLE
FEAT: Tier 1 Milestone 4 - Keyword Volume E2E

### DIFF
--- a/apps/dataforseo-app/src-tauri/Cargo.toml
+++ b/apps/dataforseo-app/src-tauri/Cargo.toml
@@ -27,7 +27,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
 
-duckdb = { version = "1", features = ["bundled"] }
+duckdb = { version = "1", features = ["bundled", "chrono"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 keyring = "3"
 
 ts-rs = { version = "10", features = ["serde-json-impl"] }

--- a/apps/dataforseo-app/src-tauri/src/api/client.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/client.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::errors::{AppError, Result};
+use crate::ratelimit::{Family, Scheduler};
 use crate::secrets::Credentials;
 
 const BASE_URL: &str = "https://api.dataforseo.com";
@@ -9,42 +10,64 @@ const BASE_URL: &str = "https://api.dataforseo.com";
 pub struct ApiClient {
     http: reqwest::Client,
     credentials: Arc<RwLock<Option<Credentials>>>,
+    scheduler: Arc<Scheduler>,
 }
 
 impl ApiClient {
-    pub fn new(credentials: Arc<RwLock<Option<Credentials>>>) -> Self {
+    pub fn new(credentials: Arc<RwLock<Option<Credentials>>>, scheduler: Arc<Scheduler>) -> Self {
         let http = reqwest::Client::builder()
             .user_agent(concat!("dataforseo-app/", env!("CARGO_PKG_VERSION")))
             .timeout(std::time::Duration::from_secs(60))
             .build()
             .expect("reqwest client should build with default config");
-        Self { http, credentials }
+        Self { http, credentials, scheduler }
     }
 
-    /// Calls the free `/v3/appendix/user_data` endpoint to validate credentials
-    /// and read account balance.
-    pub async fn user_data(&self) -> Result<serde_json::Value> {
-        let creds = self
-            .credentials
+    async fn credentials(&self) -> Result<Credentials> {
+        self.credentials
             .read()
             .await
             .clone()
-            .ok_or_else(|| AppError::Auth("credentials not set".into()))?;
+            .ok_or_else(|| AppError::Auth("credentials not set".into()))
+    }
 
+    /// Calls the free /v3/appendix/user_data endpoint.
+    pub async fn user_data(&self) -> Result<serde_json::Value> {
+        let creds = self.credentials().await?;
         let resp = self
             .http
             .get(format!("{BASE_URL}/v3/appendix/user_data"))
             .basic_auth(&creds.login, Some(&creds.password))
             .send()
             .await?;
+        Self::deserialize_or_err(resp).await
+    }
 
+    /// POST a JSON body and return the parsed response, gated by the rate
+    /// limiter for the given family.
+    pub(crate) async fn post_json(
+        &self,
+        family: Family,
+        path: &str,
+        body: &serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        self.scheduler.acquire(family).await;
+        let creds = self.credentials().await?;
+        let resp = self
+            .http
+            .post(format!("{BASE_URL}{path}"))
+            .basic_auth(&creds.login, Some(&creds.password))
+            .json(body)
+            .send()
+            .await?;
+        Self::deserialize_or_err(resp).await
+    }
+
+    async fn deserialize_or_err(resp: reqwest::Response) -> Result<serde_json::Value> {
         let status = resp.status();
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            return Err(AppError::Api {
-                status_code: status.as_u16() as u32,
-                message: body,
-            });
+            return Err(AppError::Api { status_code: status.as_u16() as u32, message: body });
         }
         Ok(resp.json().await?)
     }

--- a/apps/dataforseo-app/src-tauri/src/api/keywords_data.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/keywords_data.rs
@@ -59,13 +59,28 @@ impl ApiClient {
             )
             .await?;
 
+        // DataForSEO returns logical errors (invalid params, insufficient
+        // balance) inside the JSON body even when the HTTP status is 200.
+        // Top-level status_code == 20000 means success.
+        let api_status = raw.pointer("/status_code").and_then(|v| v.as_u64()).unwrap_or(0);
+        if api_status != 20000 {
+            let message = raw
+                .pointer("/status_message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown DataForSEO error");
+            return Err(AppError::Api {
+                status_code: api_status as u32,
+                message: message.into(),
+            });
+        }
+
         let cost = raw.pointer("/cost").and_then(|v| v.as_f64()).unwrap_or(0.0);
 
         let items = raw
             .pointer("/tasks/0/result")
             .and_then(|v| v.as_array())
             .ok_or_else(|| AppError::Api {
-                status_code: 200,
+                status_code: 20000,
                 message: "search_volume response missing tasks[0].result".into(),
             })?
             .iter()

--- a/apps/dataforseo-app/src-tauri/src/api/keywords_data.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/keywords_data.rs
@@ -1,0 +1,77 @@
+use serde::{Deserialize, Serialize};
+
+use crate::api::client::ApiClient;
+use crate::errors::{AppError, Result};
+use crate::ratelimit::Family;
+
+#[derive(Debug, Serialize)]
+pub struct SearchVolumeRequest<'a> {
+    pub keywords: &'a [String],
+    pub location_code: u32,
+    pub language_code: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SearchVolumeResponse {
+    pub items: Vec<SearchVolumeItem>,
+    pub cost: f64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SearchVolumeItem {
+    pub keyword: String,
+    pub search_volume: Option<i64>,
+    pub competition: Option<String>,
+    pub competition_index: Option<i32>,
+    pub cpc: Option<f64>,
+    pub low_top_of_page_bid: Option<f64>,
+    pub high_top_of_page_bid: Option<f64>,
+    pub monthly_searches: Option<serde_json::Value>,
+}
+
+impl ApiClient {
+    /// POST /v3/keywords_data/google_ads/search_volume/live
+    pub async fn google_ads_search_volume_live(
+        &self,
+        req: SearchVolumeRequest<'_>,
+    ) -> Result<SearchVolumeResponse> {
+        if req.keywords.is_empty() {
+            return Ok(SearchVolumeResponse { items: Vec::new(), cost: 0.0 });
+        }
+        if req.keywords.len() > 1000 {
+            return Err(AppError::Validation(
+                "search_volume accepts at most 1000 keywords per request".into(),
+            ));
+        }
+
+        // DataForSEO expects an array containing one task definition.
+        let body = serde_json::json!([{
+            "keywords": req.keywords,
+            "location_code": req.location_code,
+            "language_code": req.language_code,
+        }]);
+
+        let raw = self
+            .post_json(
+                Family::GoogleAdsLive,
+                "/v3/keywords_data/google_ads/search_volume/live",
+                &body,
+            )
+            .await?;
+
+        let cost = raw.pointer("/cost").and_then(|v| v.as_f64()).unwrap_or(0.0);
+
+        let items = raw
+            .pointer("/tasks/0/result")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| AppError::Api {
+                status_code: 200,
+                message: "search_volume response missing tasks[0].result".into(),
+            })?
+            .iter()
+            .filter_map(|item| serde_json::from_value::<SearchVolumeItem>(item.clone()).ok())
+            .collect();
+
+        Ok(SearchVolumeResponse { items, cost })
+    }
+}

--- a/apps/dataforseo-app/src-tauri/src/api/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/mod.rs
@@ -1,1 +1,2 @@
 pub mod client;
+pub mod keywords_data;

--- a/apps/dataforseo-app/src-tauri/src/commands/keywords.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/keywords.rs
@@ -35,12 +35,13 @@ pub async fn keywords_search_volume(
     language_code: String,
     use_cache: bool,
 ) -> Result<KeywordVolumeBatch> {
+    // Order-preserving dedup so the result table stays stable across runs
+    // and matches the user's input order for keywords with equal volume.
+    let mut seen = HashSet::new();
     let cleaned: Vec<String> = keywords
         .into_iter()
         .map(|k| k.trim().to_owned())
-        .filter(|k| !k.is_empty())
-        .collect::<HashSet<_>>()
-        .into_iter()
+        .filter(|k| !k.is_empty() && seen.insert(k.clone()))
         .collect();
 
     let estimated_usd = cost::estimate(&CostAction::KeywordsSearchVolume {

--- a/apps/dataforseo-app/src-tauri/src/commands/keywords.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/keywords.rs
@@ -1,0 +1,155 @@
+use std::collections::HashSet;
+
+use chrono::Duration;
+use serde::Serialize;
+use tauri::State;
+use tokio::task;
+use ts_rs::TS;
+
+use crate::api::keywords_data::SearchVolumeRequest;
+use crate::domain::cost::{self, CostAction};
+use crate::domain::types::Mode;
+use crate::errors::Result;
+use crate::state::AppState;
+use crate::store::keywords_cache::{self, KeywordVolume};
+use crate::store::ledger::{self, LedgerEntry};
+
+#[derive(Debug, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct KeywordVolumeBatch {
+    pub items: Vec<KeywordVolume>,
+    pub cache_hits: u32,
+    pub fresh: u32,
+    pub cost_usd: f64,
+    pub estimated_usd: f64,
+}
+
+const CACHE_TTL_DAYS: i64 = 30;
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn keywords_search_volume(
+    state: State<'_, AppState>,
+    keywords: Vec<String>,
+    location_code: u32,
+    language_code: String,
+    use_cache: bool,
+) -> Result<KeywordVolumeBatch> {
+    let cleaned: Vec<String> = keywords
+        .into_iter()
+        .map(|k| k.trim().to_owned())
+        .filter(|k| !k.is_empty())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    let estimated_usd = cost::estimate(&CostAction::KeywordsSearchVolume {
+        count: cleaned.len() as u32,
+        mode: Mode::Live,
+    });
+
+    // Cache lookup (blocking IO -> spawn_blocking).
+    let store = state.store.clone();
+    let cache_keywords = cleaned.clone();
+    let lang_for_cache = language_code.clone();
+    let cached = if use_cache {
+        task::spawn_blocking(move || {
+            store.with_conn(|c| {
+                keywords_cache::get_fresh(
+                    c,
+                    &cache_keywords,
+                    location_code,
+                    &lang_for_cache,
+                    Duration::days(CACHE_TTL_DAYS),
+                )
+            })
+        })
+        .await
+        .map_err(|e| crate::errors::AppError::Internal(e.to_string()))??
+    } else {
+        Default::default()
+    };
+
+    let misses: Vec<String> = cleaned
+        .iter()
+        .filter(|k| !cached.contains_key(*k))
+        .cloned()
+        .collect();
+
+    let mut fresh_rows: Vec<KeywordVolume> = Vec::new();
+    let mut api_cost = 0.0;
+
+    if !misses.is_empty() {
+        let resp = state
+            .api
+            .google_ads_search_volume_live(SearchVolumeRequest {
+                keywords: &misses,
+                location_code,
+                language_code: &language_code,
+            })
+            .await?;
+
+        api_cost = resp.cost;
+
+        fresh_rows = resp
+            .items
+            .into_iter()
+            .map(|item| KeywordVolume {
+                keyword: item.keyword,
+                search_volume: item.search_volume,
+                competition: item.competition,
+                competition_index: item.competition_index,
+                cpc: item.cpc,
+                low_top_of_page_bid: item.low_top_of_page_bid,
+                high_top_of_page_bid: item.high_top_of_page_bid,
+                monthly_searches: item.monthly_searches,
+                from_cache: false,
+            })
+            .collect();
+
+        // Persist fresh rows + ledger entry.
+        let store = state.store.clone();
+        let lang_for_write = language_code.clone();
+        let to_persist = fresh_rows.clone();
+        let request_size = misses.len() as i64;
+        task::spawn_blocking(move || -> Result<()> {
+            store.with_conn(|c| {
+                keywords_cache::put_batch(c, location_code, &lang_for_write, &to_persist)?;
+                ledger::record(
+                    c,
+                    &LedgerEntry {
+                        endpoint: "google_ads.search_volume",
+                        mode: "live",
+                        cost_usd: api_cost,
+                        estimated_usd: Some(estimated_usd),
+                        request_size: Some(request_size),
+                        response_status: Some(200),
+                        duration_ms: None,
+                        task_id: None,
+                        error: None,
+                    },
+                )
+            })
+        })
+        .await
+        .map_err(|e| crate::errors::AppError::Internal(e.to_string()))??;
+    }
+
+    let mut items: Vec<KeywordVolume> = cached.into_values().collect();
+    let cache_hits = items.len() as u32;
+    let fresh = fresh_rows.len() as u32;
+    items.extend(fresh_rows);
+    items.sort_by(|a, b| {
+        b.search_volume
+            .unwrap_or(0)
+            .cmp(&a.search_volume.unwrap_or(0))
+    });
+
+    Ok(KeywordVolumeBatch {
+        items,
+        cache_hits,
+        fresh,
+        cost_usd: api_cost,
+        estimated_usd,
+    })
+}

--- a/apps/dataforseo-app/src-tauri/src/commands/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/mod.rs
@@ -1,4 +1,4 @@
 pub mod auth;
+pub mod keywords;
 pub mod ledger;
-// TODO Tier 1: pub mod keywords;
 // TODO Tier 1: pub mod serp;

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -10,18 +10,28 @@ pub mod tasks;
 pub mod telemetry;
 
 use state::AppState;
+use tauri::Manager;
 
 pub fn run() {
     telemetry::init();
 
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
-        .manage(AppState::new())
+        .setup(|app| {
+            let dir = app
+                .path()
+                .app_local_data_dir()
+                .expect("app_local_data_dir resolves on supported platforms");
+            let db_path = dir.join("dataforseo-app.duckdb");
+            app.manage(AppState::new(db_path));
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             commands::auth::test_connection,
             commands::auth::save_credentials,
             commands::auth::clear_credentials,
             commands::ledger::estimate_cost,
+            commands::keywords::keywords_search_volume,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/dataforseo-app/src-tauri/src/ratelimit/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/ratelimit/mod.rs
@@ -1,2 +1,3 @@
-// TODO Tier 1: Token-bucket scheduler keyed on EndpointFamily.
-// See docs/DATAFORSEO_ARCHITECTURE.md Teil 6.
+pub mod scheduler;
+
+pub use scheduler::{Family, Scheduler};

--- a/apps/dataforseo-app/src-tauri/src/ratelimit/scheduler.rs
+++ b/apps/dataforseo-app/src-tauri/src/ratelimit/scheduler.rs
@@ -1,0 +1,109 @@
+//! Token-bucket per endpoint family.
+//!
+//! Source: docs/DATAFORSEO_ARCHITECTURE.md Teil 6.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use tokio::sync::Mutex;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Family {
+    GoogleAdsLive,
+    Labs,
+    SerpLive,
+    SerpTask,
+}
+
+struct Bucket {
+    capacity: f64,
+    tokens: f64,
+    refill_per_sec: f64,
+    last_refill: Instant,
+}
+
+impl Bucket {
+    fn new(capacity: f64, refill_per_sec: f64) -> Self {
+        Self { capacity, tokens: capacity, refill_per_sec, last_refill: Instant::now() }
+    }
+
+    fn refill(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * self.refill_per_sec).min(self.capacity);
+        self.last_refill = now;
+    }
+
+    fn try_take(&mut self) -> Option<Duration> {
+        self.refill();
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            None
+        } else {
+            let needed = 1.0 - self.tokens;
+            let wait_secs = needed / self.refill_per_sec;
+            Some(Duration::from_secs_f64(wait_secs))
+        }
+    }
+}
+
+pub struct Scheduler {
+    buckets: Mutex<HashMap<Family, Bucket>>,
+}
+
+impl Scheduler {
+    pub fn new() -> Self {
+        let mut buckets = HashMap::new();
+        // capacity = burst allowed, refill_per_sec = sustained rate.
+        // Tier 1 limits per docs/DATAFORSEO_API_MAPPING.md Teil 5.
+        buckets.insert(Family::GoogleAdsLive, Bucket::new(12.0, 12.0 / 60.0));
+        buckets.insert(Family::Labs, Bucket::new(60.0, 10.0));
+        buckets.insert(Family::SerpLive, Bucket::new(120.0, 20.0));
+        buckets.insert(Family::SerpTask, Bucket::new(2000.0, 2000.0 / 60.0));
+        Self { buckets: Mutex::new(buckets) }
+    }
+
+    pub async fn acquire(&self, family: Family) {
+        loop {
+            let wait = {
+                let mut buckets = self.buckets.lock().await;
+                let bucket = buckets.get_mut(&family).expect("bucket configured for every family");
+                bucket.try_take()
+            };
+            match wait {
+                None => return,
+                Some(d) => tokio::time::sleep(d).await,
+            }
+        }
+    }
+}
+
+impl Default for Scheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn first_burst_fits_capacity() {
+        let s = Scheduler::new();
+        for _ in 0..12 {
+            s.acquire(Family::GoogleAdsLive).await;
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn thirteenth_request_waits_for_refill() {
+        let s = Scheduler::new();
+        let start = tokio::time::Instant::now();
+        for _ in 0..13 {
+            s.acquire(Family::GoogleAdsLive).await;
+        }
+        let elapsed = tokio::time::Instant::now() - start;
+        assert!(elapsed >= Duration::from_secs(4));
+    }
+}

--- a/apps/dataforseo-app/src-tauri/src/state.rs
+++ b/apps/dataforseo-app/src-tauri/src/state.rs
@@ -1,28 +1,32 @@
+use std::path::PathBuf;
 use std::sync::Arc;
+
 use tokio::sync::RwLock;
 
 use crate::api::client::ApiClient;
+use crate::ratelimit::Scheduler;
 use crate::secrets::Credentials;
+use crate::store::Store;
 
 pub struct AppState {
     pub credentials: Arc<RwLock<Option<Credentials>>>,
     pub api: Arc<ApiClient>,
+    pub scheduler: Arc<Scheduler>,
+    pub store: Arc<Store>,
 }
 
 impl AppState {
-    pub fn new() -> Self {
+    pub fn new(db_path: PathBuf) -> Self {
         let initial = crate::secrets::load().unwrap_or_else(|e| {
             tracing::error!(error = %e, "failed to load credentials from keychain");
             None
         });
         let credentials = Arc::new(RwLock::new(initial));
-        let api = Arc::new(ApiClient::new(credentials.clone()));
-        Self { credentials, api }
-    }
-}
-
-impl Default for AppState {
-    fn default() -> Self {
-        Self::new()
+        let scheduler = Arc::new(Scheduler::new());
+        let api = Arc::new(ApiClient::new(credentials.clone(), scheduler.clone()));
+        let store = Arc::new(
+            Store::open(db_path).expect("failed to open DuckDB store at startup"),
+        );
+        Self { credentials, api, scheduler, store }
     }
 }

--- a/apps/dataforseo-app/src-tauri/src/store/keywords_cache.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/keywords_cache.rs
@@ -1,0 +1,129 @@
+use std::collections::HashMap;
+
+use chrono::{DateTime, Duration, Utc};
+use duckdb::{params, Connection};
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+use crate::errors::Result;
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct KeywordVolume {
+    pub keyword: String,
+    pub search_volume: Option<i64>,
+    pub competition: Option<String>,
+    pub competition_index: Option<i32>,
+    pub cpc: Option<f64>,
+    pub low_top_of_page_bid: Option<f64>,
+    pub high_top_of_page_bid: Option<f64>,
+    /// Trend data (24-month) as raw JSON for the chart.
+    pub monthly_searches: Option<serde_json::Value>,
+    pub from_cache: bool,
+}
+
+pub fn get_fresh(
+    conn: &Connection,
+    keywords: &[String],
+    location_code: u32,
+    language_code: &str,
+    max_age: Duration,
+) -> Result<HashMap<String, KeywordVolume>> {
+    if keywords.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let cutoff: DateTime<Utc> = Utc::now() - max_age;
+
+    let placeholders = (0..keywords.len())
+        .map(|i| format!("${}", i + 4))
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT keyword, search_volume, competition, competition_index, cpc,
+                low_top_of_page_bid, high_top_of_page_bid, monthly_searches
+           FROM keyword_volume_cache
+          WHERE location_code = $1
+            AND language_code = $2
+            AND fetched_at >= $3
+            AND keyword IN ({placeholders})"
+    );
+
+    let mut stmt = conn.prepare(&sql)?;
+    let mut params_vec: Vec<duckdb::types::Value> = vec![
+        (location_code as i64).into(),
+        language_code.into(),
+        cutoff.naive_utc().into(),
+    ];
+    for k in keywords {
+        params_vec.push(k.clone().into());
+    }
+    let params_refs: Vec<&dyn duckdb::ToSql> =
+        params_vec.iter().map(|v| v as &dyn duckdb::ToSql).collect();
+
+    let mut rows = stmt.query(params_refs.as_slice())?;
+    let mut out = HashMap::new();
+    while let Some(row) = rows.next()? {
+        let keyword: String = row.get(0)?;
+        let monthly: Option<String> = row.get(7)?;
+        out.insert(
+            keyword.clone(),
+            KeywordVolume {
+                keyword,
+                search_volume: row.get(1)?,
+                competition: row.get(2)?,
+                competition_index: row.get(3)?,
+                cpc: row.get(4)?,
+                low_top_of_page_bid: row.get(5)?,
+                high_top_of_page_bid: row.get(6)?,
+                monthly_searches: monthly
+                    .as_deref()
+                    .and_then(|s| serde_json::from_str(s).ok()),
+                from_cache: true,
+            },
+        );
+    }
+    Ok(out)
+}
+
+pub fn put_batch(
+    conn: &Connection,
+    location_code: u32,
+    language_code: &str,
+    rows: &[KeywordVolume],
+) -> Result<()> {
+    let mut stmt = conn.prepare(
+        "INSERT INTO keyword_volume_cache
+            (keyword, location_code, language_code, search_volume, competition,
+             competition_index, cpc, low_top_of_page_bid, high_top_of_page_bid,
+             monthly_searches, fetched_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, CURRENT_TIMESTAMP)
+         ON CONFLICT (keyword, location_code, language_code) DO UPDATE SET
+            search_volume = excluded.search_volume,
+            competition = excluded.competition,
+            competition_index = excluded.competition_index,
+            cpc = excluded.cpc,
+            low_top_of_page_bid = excluded.low_top_of_page_bid,
+            high_top_of_page_bid = excluded.high_top_of_page_bid,
+            monthly_searches = excluded.monthly_searches,
+            fetched_at = CURRENT_TIMESTAMP",
+    )?;
+    for r in rows {
+        let monthly_str = r
+            .monthly_searches
+            .as_ref()
+            .map(|v| serde_json::to_string(v).unwrap_or_default());
+        stmt.execute(params![
+            &r.keyword,
+            location_code as i64,
+            language_code,
+            r.search_volume,
+            r.competition,
+            r.competition_index,
+            r.cpc,
+            r.low_top_of_page_bid,
+            r.high_top_of_page_bid,
+            monthly_str,
+        ])?;
+    }
+    Ok(())
+}

--- a/apps/dataforseo-app/src-tauri/src/store/keywords_cache.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/keywords_cache.rs
@@ -23,7 +23,7 @@ pub struct KeywordVolume {
 }
 
 pub fn get_fresh(
-    conn: &Connection,
+    conn: &mut Connection,
     keywords: &[String],
     location_code: u32,
     language_code: &str,
@@ -86,44 +86,51 @@ pub fn get_fresh(
 }
 
 pub fn put_batch(
-    conn: &Connection,
+    conn: &mut Connection,
     location_code: u32,
     language_code: &str,
     rows: &[KeywordVolume],
 ) -> Result<()> {
-    let mut stmt = conn.prepare(
-        "INSERT INTO keyword_volume_cache
-            (keyword, location_code, language_code, search_volume, competition,
-             competition_index, cpc, low_top_of_page_bid, high_top_of_page_bid,
-             monthly_searches, fetched_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, CURRENT_TIMESTAMP)
-         ON CONFLICT (keyword, location_code, language_code) DO UPDATE SET
-            search_volume = excluded.search_volume,
-            competition = excluded.competition,
-            competition_index = excluded.competition_index,
-            cpc = excluded.cpc,
-            low_top_of_page_bid = excluded.low_top_of_page_bid,
-            high_top_of_page_bid = excluded.high_top_of_page_bid,
-            monthly_searches = excluded.monthly_searches,
-            fetched_at = CURRENT_TIMESTAMP",
-    )?;
-    for r in rows {
-        let monthly_str = r
-            .monthly_searches
-            .as_ref()
-            .map(|v| serde_json::to_string(v).unwrap_or_default());
-        stmt.execute(params![
-            &r.keyword,
-            location_code as i64,
-            language_code,
-            r.search_volume,
-            r.competition,
-            r.competition_index,
-            r.cpc,
-            r.low_top_of_page_bid,
-            r.high_top_of_page_bid,
-            monthly_str,
-        ])?;
+    if rows.is_empty() {
+        return Ok(());
     }
+    let tx = conn.transaction()?;
+    {
+        let mut stmt = tx.prepare(
+            "INSERT INTO keyword_volume_cache
+                (keyword, location_code, language_code, search_volume, competition,
+                 competition_index, cpc, low_top_of_page_bid, high_top_of_page_bid,
+                 monthly_searches, fetched_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, CURRENT_TIMESTAMP)
+             ON CONFLICT (keyword, location_code, language_code) DO UPDATE SET
+                search_volume = excluded.search_volume,
+                competition = excluded.competition,
+                competition_index = excluded.competition_index,
+                cpc = excluded.cpc,
+                low_top_of_page_bid = excluded.low_top_of_page_bid,
+                high_top_of_page_bid = excluded.high_top_of_page_bid,
+                monthly_searches = excluded.monthly_searches,
+                fetched_at = CURRENT_TIMESTAMP",
+        )?;
+        for r in rows {
+            let monthly_str = r
+                .monthly_searches
+                .as_ref()
+                .map(|v| serde_json::to_string(v).unwrap_or_default());
+            stmt.execute(params![
+                &r.keyword,
+                location_code as i64,
+                language_code,
+                r.search_volume,
+                r.competition,
+                r.competition_index,
+                r.cpc,
+                r.low_top_of_page_bid,
+                r.high_top_of_page_bid,
+                monthly_str,
+            ])?;
+        }
+    }
+    tx.commit()?;
     Ok(())
 }

--- a/apps/dataforseo-app/src-tauri/src/store/ledger.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/ledger.rs
@@ -1,0 +1,40 @@
+use duckdb::{params, Connection};
+use serde::Serialize;
+use ts_rs::TS;
+
+use crate::errors::Result;
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct LedgerEntry<'a> {
+    pub endpoint: &'a str,
+    pub mode: &'a str,
+    pub cost_usd: f64,
+    pub estimated_usd: Option<f64>,
+    pub request_size: Option<i64>,
+    pub response_status: Option<i64>,
+    pub duration_ms: Option<i64>,
+    pub task_id: Option<&'a str>,
+    pub error: Option<&'a str>,
+}
+
+pub fn record(conn: &Connection, entry: &LedgerEntry) -> Result<()> {
+    conn.execute(
+        "INSERT INTO api_calls
+            (endpoint, mode, cost_usd, estimated_usd, request_size,
+             response_status, duration_ms, task_id, error)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+        params![
+            entry.endpoint,
+            entry.mode,
+            entry.cost_usd,
+            entry.estimated_usd,
+            entry.request_size,
+            entry.response_status,
+            entry.duration_ms,
+            entry.task_id,
+            entry.error,
+        ],
+    )?;
+    Ok(())
+}

--- a/apps/dataforseo-app/src-tauri/src/store/ledger.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/ledger.rs
@@ -18,7 +18,7 @@ pub struct LedgerEntry<'a> {
     pub error: Option<&'a str>,
 }
 
-pub fn record(conn: &Connection, entry: &LedgerEntry) -> Result<()> {
+pub fn record(conn: &mut Connection, entry: &LedgerEntry) -> Result<()> {
     conn.execute(
         "INSERT INTO api_calls
             (endpoint, mode, cost_usd, estimated_usd, request_size,

--- a/apps/dataforseo-app/src-tauri/src/store/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/mod.rs
@@ -26,11 +26,12 @@ impl Store {
 
     /// Run a closure with the underlying connection. Holds a blocking mutex
     /// — async callers must wrap calls in tokio::task::spawn_blocking.
-    pub fn with_conn<T>(&self, f: impl FnOnce(&Connection) -> Result<T>) -> Result<T> {
-        let conn = self
+    /// `&mut Connection` is required by duckdb to start transactions.
+    pub fn with_conn<T>(&self, f: impl FnOnce(&mut Connection) -> Result<T>) -> Result<T> {
+        let mut conn = self
             .conn
             .lock()
             .map_err(|_| AppError::Database("store mutex poisoned".into()))?;
-        f(&conn)
+        f(&mut conn)
     }
 }

--- a/apps/dataforseo-app/src-tauri/src/store/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/mod.rs
@@ -1,3 +1,36 @@
-// TODO Tier 1: DuckDB-backed store. Schema in migrations/v0001_initial.sql.
-// Modules to add: schema (migrations runner), keywords_cache, serp_tasks,
-// serp_results, ledger.
+pub mod keywords_cache;
+pub mod ledger;
+pub mod schema;
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use duckdb::Connection;
+
+use crate::errors::{AppError, Result};
+
+pub struct Store {
+    conn: Mutex<Connection>,
+}
+
+impl Store {
+    pub fn open(path: PathBuf) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| AppError::Database(e.to_string()))?;
+        }
+        let conn = Connection::open(&path)?;
+        let store = Self { conn: Mutex::new(conn) };
+        store.with_conn(|c| schema::ensure_current(c))?;
+        Ok(store)
+    }
+
+    /// Run a closure with the underlying connection. Holds a blocking mutex
+    /// — async callers must wrap calls in tokio::task::spawn_blocking.
+    pub fn with_conn<T>(&self, f: impl FnOnce(&Connection) -> Result<T>) -> Result<T> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|_| AppError::Database("store mutex poisoned".into()))?;
+        f(&conn)
+    }
+}

--- a/apps/dataforseo-app/src-tauri/src/store/schema.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/schema.rs
@@ -1,0 +1,34 @@
+//! Schema migrations. Append-only: never edit a committed migration file.
+
+use duckdb::Connection;
+
+use crate::errors::Result;
+
+const MIGRATIONS: &[(u32, &str)] = &[(1, include_str!("../../migrations/v0001_initial.sql"))];
+
+pub fn ensure_current(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS settings (key VARCHAR PRIMARY KEY, value VARCHAR NOT NULL);",
+    )?;
+
+    let current: u32 = conn
+        .query_row(
+            "SELECT COALESCE(MAX(CAST(value AS INTEGER)), 0) FROM settings WHERE key = 'schema_version'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap_or(0);
+
+    for (version, sql) in MIGRATIONS {
+        if *version <= current {
+            continue;
+        }
+        conn.execute_batch(sql)?;
+        conn.execute(
+            "INSERT INTO settings (key, value) VALUES ('schema_version', ?)
+             ON CONFLICT (key) DO UPDATE SET value = excluded.value",
+            duckdb::params![version.to_string()],
+        )?;
+    }
+    Ok(())
+}

--- a/apps/dataforseo-app/src-tauri/src/store/schema.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/schema.rs
@@ -6,7 +6,7 @@ use crate::errors::Result;
 
 const MIGRATIONS: &[(u32, &str)] = &[(1, include_str!("../../migrations/v0001_initial.sql"))];
 
-pub fn ensure_current(conn: &Connection) -> Result<()> {
+pub fn ensure_current(conn: &mut Connection) -> Result<()> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS settings (key VARCHAR PRIMARY KEY, value VARCHAR NOT NULL);",
     )?;

--- a/apps/dataforseo-app/src/components/BulkKeywordInput.tsx
+++ b/apps/dataforseo-app/src/components/BulkKeywordInput.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from "react";
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  maxKeywords?: number;
+}
+
+export function parseKeywords(raw: string): string[] {
+  return Array.from(
+    new Set(
+      raw
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+export default function BulkKeywordInput({
+  value,
+  onChange,
+  disabled,
+  maxKeywords = 1000,
+}: Props) {
+  const keywords = useMemo(() => parseKeywords(value), [value]);
+  const overLimit = keywords.length > maxKeywords;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label htmlFor="bulk-keywords" className="text-sm font-medium text-slate-700">
+        Keywords (one per line)
+      </label>
+      <textarea
+        id="bulk-keywords"
+        rows={8}
+        spellCheck={false}
+        disabled={disabled}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded border px-2 py-1 font-mono text-sm disabled:bg-slate-50"
+        placeholder="seo agentur&#10;dataforseo&#10;keyword research"
+      />
+      <div
+        className={`flex items-center justify-between text-xs ${
+          overLimit ? "text-red-600" : "text-slate-500"
+        }`}
+      >
+        <span>
+          {keywords.length} unique keyword{keywords.length === 1 ? "" : "s"}
+        </span>
+        {overLimit && (
+          <span>Maximum {maxKeywords} keywords per request</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/dataforseo-app/src/components/CostPreview.tsx
+++ b/apps/dataforseo-app/src/components/CostPreview.tsx
@@ -1,0 +1,32 @@
+import { type CostAction, estimate } from "../lib/cost";
+import { formatUsd } from "../lib/format";
+
+interface Props {
+  action: CostAction;
+  details?: string[];
+  disabled?: boolean;
+}
+
+export default function CostPreview({ action, details, disabled }: Props) {
+  const cost = estimate(action);
+
+  return (
+    <div
+      className={`rounded border bg-slate-50 p-3 text-sm ${
+        disabled ? "opacity-60" : ""
+      }`}
+    >
+      <div className="flex items-baseline justify-between">
+        <span className="font-medium text-slate-700">Estimated cost</span>
+        <span className="font-mono text-base">{formatUsd(cost)}</span>
+      </div>
+      {details && details.length > 0 && (
+        <ul className="mt-2 list-disc pl-5 text-xs text-slate-600">
+          {details.map((d, i) => (
+            <li key={i}>{d}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/dataforseo-app/src/components/ResultsTable.tsx
+++ b/apps/dataforseo-app/src/components/ResultsTable.tsx
@@ -1,0 +1,69 @@
+import {
+  type ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { useState } from "react";
+
+interface Props<T> {
+  data: T[];
+  columns: ColumnDef<T, unknown>[];
+  emptyMessage?: string;
+}
+
+export default function ResultsTable<T>({ data, columns, emptyMessage }: Props<T>) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  if (data.length === 0) {
+    return (
+      <div className="rounded border bg-white p-8 text-center text-sm text-slate-500">
+        {emptyMessage ?? "No results yet."}
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded border bg-white">
+      <table className="min-w-full text-sm">
+        <thead className="bg-slate-50 text-left">
+          {table.getHeaderGroups().map((hg) => (
+            <tr key={hg.id}>
+              {hg.headers.map((h) => (
+                <th
+                  key={h.id}
+                  onClick={h.column.getToggleSortingHandler()}
+                  className="cursor-pointer select-none border-b px-3 py-2 font-medium text-slate-700"
+                >
+                  {flexRender(h.column.columnDef.header, h.getContext())}
+                  {{ asc: " ▲", desc: " ▼" }[h.column.getIsSorted() as string] ?? ""}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {table.getRowModel().rows.map((row) => (
+            <tr key={row.id} className="hover:bg-slate-50">
+              {row.getVisibleCells().map((cell) => (
+                <td key={cell.id} className="border-b px-3 py-2">
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -7,6 +7,33 @@ export interface UserInfo {
   balance: number;
 }
 
+export interface KeywordVolume {
+  keyword: string;
+  search_volume: number | null;
+  competition: string | null;
+  competition_index: number | null;
+  cpc: number | null;
+  low_top_of_page_bid: number | null;
+  high_top_of_page_bid: number | null;
+  monthly_searches: unknown;
+  from_cache: boolean;
+}
+
+export interface KeywordVolumeBatch {
+  items: KeywordVolume[];
+  cache_hits: number;
+  fresh: number;
+  cost_usd: number;
+  estimated_usd: number;
+}
+
+export interface KeywordsSearchVolumeArgs {
+  keywords: string[];
+  locationCode: number;
+  languageCode: string;
+  useCache: boolean;
+}
+
 export const tauriApi = {
   saveCredentials: (login: string, password: string) =>
     invoke<void>("save_credentials", { login, password }),
@@ -17,4 +44,7 @@ export const tauriApi = {
 
   estimateCost: (action: CostAction) =>
     invoke<number>("estimate_cost", { action }),
+
+  keywordsSearchVolume: (args: KeywordsSearchVolumeArgs) =>
+    invoke<KeywordVolumeBatch>("keywords_search_volume", args),
 };

--- a/apps/dataforseo-app/src/routes/KeywordsPage.tsx
+++ b/apps/dataforseo-app/src/routes/KeywordsPage.tsx
@@ -1,11 +1,140 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+
+import BulkKeywordInput, { parseKeywords } from "../components/BulkKeywordInput";
+import CostPreview from "../components/CostPreview";
+import ResultsTable from "../components/ResultsTable";
+import { formatCount, formatUsd } from "../lib/format";
+import { tauriApi, type KeywordVolume, type KeywordVolumeBatch } from "../lib/tauri";
+
+const DEFAULT_LOCATION = 2276; // Germany
+const DEFAULT_LANGUAGE = "de";
+
 export default function KeywordsPage() {
+  const [raw, setRaw] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [batch, setBatch] = useState<KeywordVolumeBatch | null>(null);
+  const [useCache, setUseCache] = useState(true);
+
+  const keywords = useMemo(() => parseKeywords(raw), [raw]);
+
+  const columns = useMemo<ColumnDef<KeywordVolume, unknown>[]>(
+    () => [
+      {
+        header: "Keyword",
+        accessorKey: "keyword",
+        cell: (ctx) => (
+          <span className="font-mono">
+            {ctx.getValue<string>()}
+            {ctx.row.original.from_cache && (
+              <span className="ml-2 rounded bg-slate-200 px-1 text-xs">cache</span>
+            )}
+          </span>
+        ),
+      },
+      {
+        header: "Volume",
+        accessorKey: "search_volume",
+        cell: (ctx) => formatCount(ctx.getValue<number>() ?? 0),
+      },
+      {
+        header: "Competition",
+        accessorKey: "competition",
+      },
+      {
+        header: "CPC",
+        accessorKey: "cpc",
+        cell: (ctx) => {
+          const v = ctx.getValue<number | null>();
+          return v != null ? formatUsd(v) : "—";
+        },
+      },
+    ],
+    [],
+  );
+
+  async function onRun() {
+    if (keywords.length === 0 || keywords.length > 1000) return;
+    setBusy(true);
+    try {
+      const result = await tauriApi.keywordsSearchVolume({
+        keywords,
+        locationCode: DEFAULT_LOCATION,
+        languageCode: DEFAULT_LANGUAGE,
+        useCache,
+      });
+      setBatch(result);
+      toast.success(
+        `${result.fresh} fetched, ${result.cache_hits} from cache (${formatUsd(result.cost_usd)})`,
+      );
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
-    <section>
-      <h2 className="text-xl font-semibold">Keywords</h2>
-      <p className="mt-2 text-sm text-slate-600">
-        Tier 1: Volume, Discover (suggestions), Related. Implementation per
-        docs/DATAFORSEO_ARCHITECTURE.md Teil 10.
-      </p>
+    <section className="flex flex-col gap-6">
+      <header>
+        <h2 className="text-xl font-semibold">Keyword Volume</h2>
+        <p className="text-sm text-slate-600">
+          Google Ads search volume, competition, and CPC for up to 1000 keywords per call.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_320px]">
+        <BulkKeywordInput value={raw} onChange={setRaw} disabled={busy} />
+
+        <div className="flex flex-col gap-3">
+          <CostPreview
+            action={{
+              kind: "KeywordsSearchVolume",
+              count: keywords.length,
+              mode: "live",
+            }}
+            details={[
+              `${keywords.length} unique keywords`,
+              `Location ${DEFAULT_LOCATION}, Language ${DEFAULT_LANGUAGE}`,
+              useCache ? "Cache reused where possible" : "Cache disabled",
+            ]}
+            disabled={keywords.length === 0 || busy}
+          />
+
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={useCache}
+              onChange={(e) => setUseCache(e.target.checked)}
+              disabled={busy}
+            />
+            Use 30-day cache
+          </label>
+
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={busy || keywords.length === 0 || keywords.length > 1000}
+            className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+          >
+            {busy ? "Running…" : "Run"}
+          </button>
+        </div>
+      </div>
+
+      {batch && (
+        <div className="text-xs text-slate-500">
+          {batch.items.length} rows · {batch.cache_hits} from cache · {batch.fresh} freshly fetched ·
+          actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+        </div>
+      )}
+
+      <ResultsTable
+        data={batch?.items ?? []}
+        columns={columns}
+        emptyMessage="Enter keywords above and click Run."
+      />
     </section>
   );
 }


### PR DESCRIPTION
## Summary

First end-to-end feature on top of the Tier 1 skeleton: Google Ads search_volume Live wired all the way from the React form to the DuckDB cache and ledger.

Stacked on PR #15 (skeleton). Rebases onto main once #15 merges.

## What works after this PR

1. User pastes keywords into the BulkKeywordInput on /keywords.
2. CostPreview updates live as they type (TS mirror of the Rust estimator).
3. User clicks Run.
4. Backend pipeline:
   - Cache lookup: any keyword fresh in the 30-day cache returns immediately.
   - For cache misses, the rate-limiter (12 rpm / Google Ads Live) gates the call.
   - api::keywords_data posts the request and parses the response.
   - Fresh rows are written to keyword_volume_cache via spawn_blocking.
   - api_calls gets a row with both estimated and actual cost.
5. ResultsTable shows merged results with a cache pill per row, plus a summary line: cache_hits, fresh, actual cost, estimated cost.

## Backend changes (src-tauri/)

- ratelimit::Scheduler: token-bucket per Family with tokio::time-paused tests.
- store::Store: DuckDB Mutex<Connection> wrapper, opened against app_local_data_dir. with_conn is the only access path.
- store::schema: append-only migration runner. v0001 applies on first open.
- store::keywords_cache: get_fresh / put_batch with 30-day TTL.
- store::ledger: append api_calls rows including estimated vs actual cost.
- api::client: post_json gates requests through the scheduler; user_data refactored to share the response decoder.
- api::keywords_data: typed search_volume request + response.
- commands::keywords::keywords_search_volume: orchestrates the cache + API + ledger pipeline. Single Tauri command for the route.
- state::AppState now holds Store + Scheduler. Initialized in lib.rs setup() so app_local_data_dir is resolvable.
- Cargo.toml: chrono dep + duckdb chrono feature.

## Frontend changes (src/)

- BulkKeywordInput, CostPreview, ResultsTable: shared components, will be reused for Labs and SERP.
- KeywordsPage: replaces the placeholder stub with a working Volume tab.
- tauri.ts: keywordsSearchVolume wrapper + KeywordVolume / KeywordVolumeBatch types.

## Out of scope, deferred to later milestones

- The 24-month trend chart per keyword (architecture Teil 10 lists it; the data is already in monthly_searches but not yet rendered).
- Standard-Queue mode for search_volume (Tier 1 Milestone 7 will reuse the SERP task pipeline pattern).
- Keyword Suggestions, Related, For-Domain (Milestone 5).

## Test plan
- [ ] cd apps/dataforseo-app/src-tauri && cargo test (cost + scheduler tests).
- [ ] cd apps/dataforseo-app && npm run test (cost mirror parity).
- [ ] npm run tauri:dev with valid credentials, run a 5-keyword query, confirm results appear, run again to see cache hits, check Settings > Test Connection still works.
- [ ] Inspect DuckDB at ~/.local/share/com.bluebranch.dataforseo-app/dataforseo-app.duckdb after a run: keyword_volume_cache and api_calls should be populated.


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_