### PR TITLE
FEAT: Tier 1 Milestone 5 - Labs keyword Suggestions + Related

### DIFF
--- a/apps/dataforseo-app/src-tauri/src/api/keywords_data.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/keywords_data.rs
@@ -79,9 +79,8 @@ impl ApiClient {
         let items = raw
             .pointer("/tasks/0/result")
             .and_then(|v| v.as_array())
-            .ok_or_else(|| AppError::Api {
-                status_code: 20000,
-                message: "search_volume response missing tasks[0].result".into(),
+            .ok_or_else(|| {
+                AppError::Parse("search_volume response missing tasks[0].result".into())
             })?
             .iter()
             .filter_map(|item| serde_json::from_value::<SearchVolumeItem>(item.clone()).ok())

--- a/apps/dataforseo-app/src-tauri/src/api/labs.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/labs.rs
@@ -1,0 +1,138 @@
+//! DataForSEO Labs API — Google endpoints.
+//!
+//! Suggestions and Related share a near-identical response shape, so they
+//! return the same LabsKeywordItem type. Other Labs endpoints (for_site,
+//! ranked_keywords) live in their own modules with their own response types.
+
+use serde::Deserialize;
+
+use crate::api::client::ApiClient;
+use crate::errors::{AppError, Result};
+use crate::ratelimit::Family;
+
+#[derive(Debug, Deserialize)]
+pub struct LabsKeywordItem {
+    pub keyword: String,
+    pub search_volume: Option<i64>,
+    pub competition: Option<String>,
+    pub competition_index: Option<i32>,
+    pub cpc: Option<f64>,
+    pub keyword_difficulty: Option<i32>,
+}
+
+#[derive(Debug)]
+pub struct LabsResponse {
+    pub items: Vec<LabsKeywordItem>,
+    pub cost: f64,
+}
+
+impl ApiClient {
+    pub async fn labs_keyword_suggestions(
+        &self,
+        seed: &str,
+        location_code: u32,
+        language_code: &str,
+        limit: u32,
+    ) -> Result<LabsResponse> {
+        let body = serde_json::json!([{
+            "keyword": seed,
+            "location_code": location_code,
+            "language_code": language_code,
+            "limit": limit.min(1000),
+        }]);
+        let raw = self
+            .post_json(
+                Family::Labs,
+                "/v3/dataforseo_labs/google/keyword_suggestions/live",
+                &body,
+            )
+            .await?;
+        parse_labs_response(&raw)
+    }
+
+    pub async fn labs_related_keywords(
+        &self,
+        seed: &str,
+        location_code: u32,
+        language_code: &str,
+        depth: u32,
+    ) -> Result<LabsResponse> {
+        let body = serde_json::json!([{
+            "keyword": seed,
+            "location_code": location_code,
+            "language_code": language_code,
+            "depth": depth.clamp(1, 4),
+        }]);
+        let raw = self
+            .post_json(
+                Family::Labs,
+                "/v3/dataforseo_labs/google/related_keywords/live",
+                &body,
+            )
+            .await?;
+        parse_labs_response(&raw)
+    }
+}
+
+fn parse_labs_response(raw: &serde_json::Value) -> Result<LabsResponse> {
+    let api_status = raw.pointer("/status_code").and_then(|v| v.as_u64()).unwrap_or(0);
+    if api_status != 20000 {
+        let message = raw
+            .pointer("/status_message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown DataForSEO error");
+        return Err(AppError::Api {
+            status_code: api_status as u32,
+            message: message.into(),
+        });
+    }
+
+    let cost = raw.pointer("/cost").and_then(|v| v.as_f64()).unwrap_or(0.0);
+
+    // Both endpoints nest the keyword list at tasks[0].result[0].items[].
+    // The keyword payload itself sits at .keyword_data.keyword for related,
+    // and at the top level for suggestions — flatten via two pointer attempts.
+    let raw_items = raw
+        .pointer("/tasks/0/result/0/items")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| AppError::Api {
+            status_code: 20000,
+            message: "labs response missing tasks[0].result[0].items".into(),
+        })?;
+
+    let items = raw_items
+        .iter()
+        .filter_map(|raw_item| {
+            // For related_keywords each item wraps the actual keyword in
+            // .keyword_data; for suggestions the fields are top-level.
+            let target = raw_item
+                .pointer("/keyword_data/keyword_info")
+                .or_else(|| Some(raw_item))?;
+            let keyword = target
+                .pointer("/keyword")
+                .or_else(|| raw_item.pointer("/keyword_data/keyword"))
+                .or_else(|| raw_item.pointer("/keyword"))
+                .and_then(|v| v.as_str())?
+                .to_owned();
+            Some(LabsKeywordItem {
+                keyword,
+                search_volume: target.pointer("/search_volume").and_then(|v| v.as_i64()),
+                competition: target
+                    .pointer("/competition")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_owned()),
+                competition_index: target
+                    .pointer("/competition_index")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n as i32),
+                cpc: target.pointer("/cpc").and_then(|v| v.as_f64()),
+                keyword_difficulty: raw_item
+                    .pointer("/keyword_properties/keyword_difficulty")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n as i32),
+            })
+        })
+        .collect();
+
+    Ok(LabsResponse { items, cost })
+}

--- a/apps/dataforseo-app/src-tauri/src/api/labs.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/labs.rs
@@ -95,9 +95,8 @@ fn parse_labs_response(raw: &serde_json::Value) -> Result<LabsResponse> {
     let raw_items = raw
         .pointer("/tasks/0/result/0/items")
         .and_then(|v| v.as_array())
-        .ok_or_else(|| AppError::Api {
-            status_code: 20000,
-            message: "labs response missing tasks[0].result[0].items".into(),
+        .ok_or_else(|| {
+            AppError::Parse("labs response missing tasks[0].result[0].items".into())
         })?;
 
     let items = raw_items

--- a/apps/dataforseo-app/src-tauri/src/api/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/mod.rs
@@ -1,2 +1,3 @@
 pub mod client;
 pub mod keywords_data;
+pub mod labs;

--- a/apps/dataforseo-app/src-tauri/src/commands/keywords.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/keywords.rs
@@ -7,6 +7,7 @@ use tokio::task;
 use ts_rs::TS;
 
 use crate::api::keywords_data::SearchVolumeRequest;
+use crate::api::labs::LabsKeywordItem;
 use crate::domain::cost::{self, CostAction};
 use crate::domain::types::Mode;
 use crate::errors::Result;
@@ -153,4 +154,118 @@ pub async fn keywords_search_volume(
         cost_usd: api_cost,
         estimated_usd,
     })
+}
+
+#[derive(Debug, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct LabsKeyword {
+    pub keyword: String,
+    pub search_volume: Option<i64>,
+    pub competition: Option<String>,
+    pub competition_index: Option<i32>,
+    pub cpc: Option<f64>,
+    pub keyword_difficulty: Option<i32>,
+}
+
+#[derive(Debug, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct LabsBatch {
+    pub items: Vec<LabsKeyword>,
+    pub cost_usd: f64,
+    pub estimated_usd: f64,
+}
+
+impl From<LabsKeywordItem> for LabsKeyword {
+    fn from(it: LabsKeywordItem) -> Self {
+        Self {
+            keyword: it.keyword,
+            search_volume: it.search_volume,
+            competition: it.competition,
+            competition_index: it.competition_index,
+            cpc: it.cpc,
+            keyword_difficulty: it.keyword_difficulty,
+        }
+    }
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn keywords_suggestions(
+    state: State<'_, AppState>,
+    seed: String,
+    location_code: u32,
+    language_code: String,
+    limit: u32,
+) -> Result<LabsBatch> {
+    let estimated_usd = cost::estimate(&CostAction::KeywordsSuggestions { mode: Mode::Live });
+
+    let resp = state
+        .api
+        .labs_keyword_suggestions(&seed, location_code, &language_code, limit)
+        .await?;
+
+    record_labs_call(state.clone(), "labs.keyword_suggestions", &resp, estimated_usd).await?;
+
+    Ok(LabsBatch {
+        items: resp.items.into_iter().map(LabsKeyword::from).collect(),
+        cost_usd: resp.cost,
+        estimated_usd,
+    })
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn keywords_related(
+    state: State<'_, AppState>,
+    seed: String,
+    location_code: u32,
+    language_code: String,
+    depth: u32,
+) -> Result<LabsBatch> {
+    let estimated_usd = cost::estimate(&CostAction::KeywordsRelated { depth, mode: Mode::Live });
+
+    let resp = state
+        .api
+        .labs_related_keywords(&seed, location_code, &language_code, depth)
+        .await?;
+
+    record_labs_call(state.clone(), "labs.related_keywords", &resp, estimated_usd).await?;
+
+    Ok(LabsBatch {
+        items: resp.items.into_iter().map(LabsKeyword::from).collect(),
+        cost_usd: resp.cost,
+        estimated_usd,
+    })
+}
+
+async fn record_labs_call(
+    state: State<'_, AppState>,
+    endpoint: &'static str,
+    resp: &crate::api::labs::LabsResponse,
+    estimated_usd: f64,
+) -> Result<()> {
+    let store = state.store.clone();
+    let cost = resp.cost;
+    let items_len = resp.items.len() as i64;
+    task::spawn_blocking(move || -> Result<()> {
+        store.with_conn(|c| {
+            ledger::record(
+                c,
+                &LedgerEntry {
+                    endpoint,
+                    mode: "live",
+                    cost_usd: cost,
+                    estimated_usd: Some(estimated_usd),
+                    request_size: Some(items_len),
+                    response_status: Some(20000),
+                    duration_ms: None,
+                    task_id: None,
+                    error: None,
+                },
+            )
+        })
+    })
+    .await
+    .map_err(|e| crate::errors::AppError::Internal(e.to_string()))??;
+    Ok(())
 }

--- a/apps/dataforseo-app/src-tauri/src/errors.rs
+++ b/apps/dataforseo-app/src-tauri/src/errors.rs
@@ -24,6 +24,12 @@ pub enum AppError {
     #[error("api error {status_code}: {message}")]
     Api { status_code: u32, message: String },
 
+    /// Response was structurally unexpected even though the upstream API
+    /// reported success. Distinct from Api so callers can tell a successful
+    /// API call with a malformed body apart from an explicit upstream error.
+    #[error("response parse error: {0}")]
+    Parse(String),
+
     #[error("internal: {0}")]
     Internal(String),
 }

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -32,6 +32,8 @@ pub fn run() {
             commands::auth::clear_credentials,
             commands::ledger::estimate_cost,
             commands::keywords::keywords_search_volume,
+            commands::keywords::keywords_suggestions,
+            commands::keywords::keywords_related,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -34,6 +34,27 @@ export interface KeywordsSearchVolumeArgs {
   useCache: boolean;
 }
 
+export interface LabsKeyword {
+  keyword: string;
+  search_volume: number | null;
+  competition: string | null;
+  competition_index: number | null;
+  cpc: number | null;
+  keyword_difficulty: number | null;
+}
+
+export interface LabsBatch {
+  items: LabsKeyword[];
+  cost_usd: number;
+  estimated_usd: number;
+}
+
+export interface LabsSeedArgs {
+  seed: string;
+  locationCode: number;
+  languageCode: string;
+}
+
 export const tauriApi = {
   saveCredentials: (login: string, password: string) =>
     invoke<void>("save_credentials", { login, password }),
@@ -47,4 +68,10 @@ export const tauriApi = {
 
   keywordsSearchVolume: (args: KeywordsSearchVolumeArgs) =>
     invoke<KeywordVolumeBatch>("keywords_search_volume", args),
+
+  keywordsSuggestions: (args: LabsSeedArgs & { limit: number }) =>
+    invoke<LabsBatch>("keywords_suggestions", args),
+
+  keywordsRelated: (args: LabsSeedArgs & { depth: number }) =>
+    invoke<LabsBatch>("keywords_related", args),
 };

--- a/apps/dataforseo-app/src/routes/KeywordsPage.tsx
+++ b/apps/dataforseo-app/src/routes/KeywordsPage.tsx
@@ -1,140 +1,49 @@
-import type { ColumnDef } from "@tanstack/react-table";
-import { useMemo, useState } from "react";
-import toast from "react-hot-toast";
+import { useState } from "react";
 
-import BulkKeywordInput, { parseKeywords } from "../components/BulkKeywordInput";
-import CostPreview from "../components/CostPreview";
-import ResultsTable from "../components/ResultsTable";
-import { formatCount, formatUsd } from "../lib/format";
-import { tauriApi, type KeywordVolume, type KeywordVolumeBatch } from "../lib/tauri";
+import RelatedTab from "./keywords/RelatedTab";
+import SuggestionsTab from "./keywords/SuggestionsTab";
+import VolumeTab from "./keywords/VolumeTab";
 
-const DEFAULT_LOCATION = 2276; // Germany
-const DEFAULT_LANGUAGE = "de";
+const TABS = [
+  { id: "volume", label: "Volume" },
+  { id: "suggestions", label: "Suggestions" },
+  { id: "related", label: "Related" },
+] as const;
+
+type TabId = (typeof TABS)[number]["id"];
 
 export default function KeywordsPage() {
-  const [raw, setRaw] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [batch, setBatch] = useState<KeywordVolumeBatch | null>(null);
-  const [useCache, setUseCache] = useState(true);
-
-  const keywords = useMemo(() => parseKeywords(raw), [raw]);
-
-  const columns = useMemo<ColumnDef<KeywordVolume, unknown>[]>(
-    () => [
-      {
-        header: "Keyword",
-        accessorKey: "keyword",
-        cell: (ctx) => (
-          <span className="font-mono">
-            {ctx.getValue<string>()}
-            {ctx.row.original.from_cache && (
-              <span className="ml-2 rounded bg-slate-200 px-1 text-xs">cache</span>
-            )}
-          </span>
-        ),
-      },
-      {
-        header: "Volume",
-        accessorKey: "search_volume",
-        cell: (ctx) => formatCount(ctx.getValue<number>() ?? 0),
-      },
-      {
-        header: "Competition",
-        accessorKey: "competition",
-      },
-      {
-        header: "CPC",
-        accessorKey: "cpc",
-        cell: (ctx) => {
-          const v = ctx.getValue<number | null>();
-          return v != null ? formatUsd(v) : "—";
-        },
-      },
-    ],
-    [],
-  );
-
-  async function onRun() {
-    if (keywords.length === 0 || keywords.length > 1000) return;
-    setBusy(true);
-    try {
-      const result = await tauriApi.keywordsSearchVolume({
-        keywords,
-        locationCode: DEFAULT_LOCATION,
-        languageCode: DEFAULT_LANGUAGE,
-        useCache,
-      });
-      setBatch(result);
-      toast.success(
-        `${result.fresh} fetched, ${result.cache_hits} from cache (${formatUsd(result.cost_usd)})`,
-      );
-    } catch (e) {
-      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
-    } finally {
-      setBusy(false);
-    }
-  }
+  const [active, setActive] = useState<TabId>("volume");
 
   return (
     <section className="flex flex-col gap-6">
       <header>
-        <h2 className="text-xl font-semibold">Keyword Volume</h2>
+        <h2 className="text-xl font-semibold">Keywords</h2>
         <p className="text-sm text-slate-600">
-          Google Ads search volume, competition, and CPC for up to 1000 keywords per call.
+          Volume from Google Ads, plus Suggestions and Related from DataForSEO Labs.
         </p>
       </header>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_320px]">
-        <BulkKeywordInput value={raw} onChange={setRaw} disabled={busy} />
-
-        <div className="flex flex-col gap-3">
-          <CostPreview
-            action={{
-              kind: "KeywordsSearchVolume",
-              count: keywords.length,
-              mode: "live",
-            }}
-            details={[
-              `${keywords.length} unique keywords`,
-              `Location ${DEFAULT_LOCATION}, Language ${DEFAULT_LANGUAGE}`,
-              useCache ? "Cache reused where possible" : "Cache disabled",
-            ]}
-            disabled={keywords.length === 0 || busy}
-          />
-
-          <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={useCache}
-              onChange={(e) => setUseCache(e.target.checked)}
-              disabled={busy}
-            />
-            Use 30-day cache
-          </label>
-
+      <nav className="flex gap-1 border-b">
+        {TABS.map((tab) => (
           <button
+            key={tab.id}
             type="button"
-            onClick={onRun}
-            disabled={busy || keywords.length === 0 || keywords.length > 1000}
-            className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+            onClick={() => setActive(tab.id)}
+            className={`-mb-px border-b-2 px-3 py-1.5 text-sm transition-colors ${
+              active === tab.id
+                ? "border-slate-800 font-medium text-slate-800"
+                : "border-transparent text-slate-500 hover:text-slate-700"
+            }`}
           >
-            {busy ? "Running…" : "Run"}
+            {tab.label}
           </button>
-        </div>
-      </div>
+        ))}
+      </nav>
 
-      {batch && (
-        <div className="text-xs text-slate-500">
-          {batch.items.length} rows · {batch.cache_hits} from cache · {batch.fresh} freshly fetched ·
-          actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
-        </div>
-      )}
-
-      <ResultsTable
-        data={batch?.items ?? []}
-        columns={columns}
-        emptyMessage="Enter keywords above and click Run."
-      />
+      {active === "volume" && <VolumeTab />}
+      {active === "suggestions" && <SuggestionsTab />}
+      {active === "related" && <RelatedTab />}
     </section>
   );
 }

--- a/apps/dataforseo-app/src/routes/keywords/RelatedTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/RelatedTab.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+
+import { tauriApi } from "../../lib/tauri";
+import SeedTab from "./SeedTab";
+
+const DEFAULT_LOCATION = 2276;
+const DEFAULT_LANGUAGE = "de";
+
+export default function RelatedTab() {
+  const [depth, setDepth] = useState(2);
+
+  return (
+    <SeedTab
+      title="Related Keywords"
+      description="Ideas pulled from Googles 'searches related to' section. Higher depth costs more."
+      costAction={() => ({ kind: "KeywordsRelated", depth, mode: "live" })}
+      extraControls={
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-slate-700">Depth: {depth}</span>
+          <input
+            type="range"
+            min={1}
+            max={4}
+            step={1}
+            value={depth}
+            onChange={(e) => setDepth(parseInt(e.target.value, 10))}
+          />
+          <span className="text-xs text-slate-500">
+            Each level expands related keywords of the previous level (cost scales linearly).
+          </span>
+        </label>
+      }
+      run={(seed) =>
+        tauriApi.keywordsRelated({
+          seed,
+          locationCode: DEFAULT_LOCATION,
+          languageCode: DEFAULT_LANGUAGE,
+          depth,
+        })
+      }
+    />
+  );
+}

--- a/apps/dataforseo-app/src/routes/keywords/RelatedTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/RelatedTab.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
+import type { CostAction } from "../../lib/cost";
 import { tauriApi } from "../../lib/tauri";
 import SeedTab from "./SeedTab";
 
@@ -9,11 +10,16 @@ const DEFAULT_LANGUAGE = "de";
 export default function RelatedTab() {
   const [depth, setDepth] = useState(2);
 
+  const costAction = useMemo<CostAction>(
+    () => ({ kind: "KeywordsRelated", depth, mode: "live" }),
+    [depth],
+  );
+
   return (
     <SeedTab
       title="Related Keywords"
       description="Ideas pulled from Googles 'searches related to' section. Higher depth costs more."
-      costAction={() => ({ kind: "KeywordsRelated", depth, mode: "live" })}
+      costAction={costAction}
       extraControls={
         <label className="flex flex-col gap-1 text-sm">
           <span className="text-slate-700">Depth: {depth}</span>

--- a/apps/dataforseo-app/src/routes/keywords/SeedTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/SeedTab.tsx
@@ -1,0 +1,126 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+
+import CostPreview from "../../components/CostPreview";
+import ResultsTable from "../../components/ResultsTable";
+import type { CostAction } from "../../lib/cost";
+import { formatCount, formatUsd } from "../../lib/format";
+import { type LabsBatch, type LabsKeyword } from "../../lib/tauri";
+
+const DEFAULT_LOCATION = 2276;
+const DEFAULT_LANGUAGE = "de";
+
+interface Props {
+  title: string;
+  description: string;
+  costAction: (seed: string) => CostAction;
+  /// Extra control rendered above the Run button (e.g. depth slider).
+  extraControls?: React.ReactNode;
+  run: (seed: string) => Promise<LabsBatch>;
+}
+
+export default function SeedTab({ title, description, costAction, extraControls, run }: Props) {
+  const [seed, setSeed] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [batch, setBatch] = useState<LabsBatch | null>(null);
+
+  const trimmed = seed.trim();
+  const action = useMemo(() => costAction(trimmed), [costAction, trimmed]);
+
+  const columns = useMemo<ColumnDef<LabsKeyword, unknown>[]>(
+    () => [
+      { header: "Keyword", accessorKey: "keyword", cell: (ctx) => <span className="font-mono">{ctx.getValue<string>()}</span> },
+      {
+        header: "Volume",
+        accessorKey: "search_volume",
+        cell: (ctx) => formatCount(ctx.getValue<number>() ?? 0),
+      },
+      { header: "Competition", accessorKey: "competition" },
+      {
+        header: "CPC",
+        accessorKey: "cpc",
+        cell: (ctx) => {
+          const v = ctx.getValue<number | null>();
+          return v != null ? formatUsd(v) : "—";
+        },
+      },
+      {
+        header: "Difficulty",
+        accessorKey: "keyword_difficulty",
+        cell: (ctx) => ctx.getValue<number | null>() ?? "—",
+      },
+    ],
+    [],
+  );
+
+  async function onRun() {
+    if (!trimmed) return;
+    setBusy(true);
+    try {
+      const result = await run(trimmed);
+      setBatch(result);
+      toast.success(`${result.items.length} keywords (${formatUsd(result.cost_usd)})`);
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h3 className="text-lg font-semibold">{title}</h3>
+        <p className="text-sm text-slate-600">{description}</p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_320px]">
+        <div className="flex flex-col gap-2">
+          <label htmlFor="seed" className="text-sm font-medium text-slate-700">
+            Seed keyword
+          </label>
+          <input
+            id="seed"
+            type="text"
+            value={seed}
+            onChange={(e) => setSeed(e.target.value)}
+            disabled={busy}
+            className="rounded border px-2 py-1 font-mono text-sm disabled:bg-slate-50"
+            placeholder="seo agentur"
+            autoComplete="off"
+          />
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <CostPreview
+            action={action}
+            details={[`Location ${DEFAULT_LOCATION}, Language ${DEFAULT_LANGUAGE}`]}
+            disabled={!trimmed || busy}
+          />
+          {extraControls}
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={busy || !trimmed}
+            className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+          >
+            {busy ? "Running…" : "Run"}
+          </button>
+        </div>
+      </div>
+
+      {batch && (
+        <div className="text-xs text-slate-500">
+          {batch.items.length} rows · actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+        </div>
+      )}
+
+      <ResultsTable
+        data={batch?.items ?? []}
+        columns={columns}
+        emptyMessage="Enter a seed keyword above and click Run."
+      />
+    </div>
+  );
+}

--- a/apps/dataforseo-app/src/routes/keywords/SeedTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/SeedTab.tsx
@@ -14,7 +14,9 @@ const DEFAULT_LANGUAGE = "de";
 interface Props {
   title: string;
   description: string;
-  costAction: (seed: string) => CostAction;
+  /// Cost preview action. Pass a stable (memoized) value from the parent so
+  /// the CostPreview doesn't re-render on every keystroke in the seed input.
+  costAction: CostAction;
   /// Extra control rendered above the Run button (e.g. depth slider).
   extraControls?: React.ReactNode;
   run: (seed: string) => Promise<LabsBatch>;
@@ -26,7 +28,6 @@ export default function SeedTab({ title, description, costAction, extraControls,
   const [batch, setBatch] = useState<LabsBatch | null>(null);
 
   const trimmed = seed.trim();
-  const action = useMemo(() => costAction(trimmed), [costAction, trimmed]);
 
   const columns = useMemo<ColumnDef<LabsKeyword, unknown>[]>(
     () => [
@@ -94,7 +95,7 @@ export default function SeedTab({ title, description, costAction, extraControls,
 
         <div className="flex flex-col gap-3">
           <CostPreview
-            action={action}
+            action={costAction}
             details={[`Location ${DEFAULT_LOCATION}, Language ${DEFAULT_LANGUAGE}`]}
             disabled={!trimmed || busy}
           />

--- a/apps/dataforseo-app/src/routes/keywords/SuggestionsTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/SuggestionsTab.tsx
@@ -1,0 +1,23 @@
+import { tauriApi } from "../../lib/tauri";
+import SeedTab from "./SeedTab";
+
+const DEFAULT_LOCATION = 2276;
+const DEFAULT_LANGUAGE = "de";
+
+export default function SuggestionsTab() {
+  return (
+    <SeedTab
+      title="Keyword Suggestions"
+      description="Long-tail keywords that contain the seed term, ranked by search volume."
+      costAction={() => ({ kind: "KeywordsSuggestions", mode: "live" })}
+      run={(seed) =>
+        tauriApi.keywordsSuggestions({
+          seed,
+          locationCode: DEFAULT_LOCATION,
+          languageCode: DEFAULT_LANGUAGE,
+          limit: 200,
+        })
+      }
+    />
+  );
+}

--- a/apps/dataforseo-app/src/routes/keywords/SuggestionsTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/SuggestionsTab.tsx
@@ -1,15 +1,18 @@
+import type { CostAction } from "../../lib/cost";
 import { tauriApi } from "../../lib/tauri";
 import SeedTab from "./SeedTab";
 
 const DEFAULT_LOCATION = 2276;
 const DEFAULT_LANGUAGE = "de";
 
+const SUGGESTIONS_COST: CostAction = { kind: "KeywordsSuggestions", mode: "live" };
+
 export default function SuggestionsTab() {
   return (
     <SeedTab
       title="Keyword Suggestions"
       description="Long-tail keywords that contain the seed term, ranked by search volume."
-      costAction={() => ({ kind: "KeywordsSuggestions", mode: "live" })}
+      costAction={SUGGESTIONS_COST}
       run={(seed) =>
         tauriApi.keywordsSuggestions({
           seed,

--- a/apps/dataforseo-app/src/routes/keywords/VolumeTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/VolumeTab.tsx
@@ -1,0 +1,127 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+
+import BulkKeywordInput, { parseKeywords } from "../../components/BulkKeywordInput";
+import CostPreview from "../../components/CostPreview";
+import ResultsTable from "../../components/ResultsTable";
+import { formatCount, formatUsd } from "../../lib/format";
+import { tauriApi, type KeywordVolume, type KeywordVolumeBatch } from "../../lib/tauri";
+
+const DEFAULT_LOCATION = 2276;
+const DEFAULT_LANGUAGE = "de";
+
+export default function VolumeTab() {
+  const [raw, setRaw] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [batch, setBatch] = useState<KeywordVolumeBatch | null>(null);
+  const [useCache, setUseCache] = useState(true);
+
+  const keywords = useMemo(() => parseKeywords(raw), [raw]);
+
+  const columns = useMemo<ColumnDef<KeywordVolume, unknown>[]>(
+    () => [
+      {
+        header: "Keyword",
+        accessorKey: "keyword",
+        cell: (ctx) => (
+          <span className="font-mono">
+            {ctx.getValue<string>()}
+            {ctx.row.original.from_cache && (
+              <span className="ml-2 rounded bg-slate-200 px-1 text-xs">cache</span>
+            )}
+          </span>
+        ),
+      },
+      {
+        header: "Volume",
+        accessorKey: "search_volume",
+        cell: (ctx) => formatCount(ctx.getValue<number>() ?? 0),
+      },
+      { header: "Competition", accessorKey: "competition" },
+      {
+        header: "CPC",
+        accessorKey: "cpc",
+        cell: (ctx) => {
+          const v = ctx.getValue<number | null>();
+          return v != null ? formatUsd(v) : "—";
+        },
+      },
+    ],
+    [],
+  );
+
+  async function onRun() {
+    if (keywords.length === 0 || keywords.length > 1000) return;
+    setBusy(true);
+    try {
+      const result = await tauriApi.keywordsSearchVolume({
+        keywords,
+        locationCode: DEFAULT_LOCATION,
+        languageCode: DEFAULT_LANGUAGE,
+        useCache,
+      });
+      setBatch(result);
+      toast.success(
+        `${result.fresh} fetched, ${result.cache_hits} from cache (${formatUsd(result.cost_usd)})`,
+      );
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_320px]">
+        <BulkKeywordInput value={raw} onChange={setRaw} disabled={busy} />
+        <div className="flex flex-col gap-3">
+          <CostPreview
+            action={{
+              kind: "KeywordsSearchVolume",
+              count: keywords.length,
+              mode: "live",
+            }}
+            details={[
+              `${keywords.length} unique keywords`,
+              `Location ${DEFAULT_LOCATION}, Language ${DEFAULT_LANGUAGE}`,
+              useCache ? "Cache reused where possible" : "Cache disabled",
+            ]}
+            disabled={keywords.length === 0 || busy}
+          />
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={useCache}
+              onChange={(e) => setUseCache(e.target.checked)}
+              disabled={busy}
+            />
+            Use 30-day cache
+          </label>
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={busy || keywords.length === 0 || keywords.length > 1000}
+            className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+          >
+            {busy ? "Running…" : "Run"}
+          </button>
+        </div>
+      </div>
+
+      {batch && (
+        <div className="text-xs text-slate-500">
+          {batch.items.length} rows · {batch.cache_hits} from cache · {batch.fresh} freshly fetched ·
+          actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+        </div>
+      )}
+
+      <ResultsTable
+        data={batch?.items ?? []}
+        columns={columns}
+        emptyMessage="Enter keywords above and click Run."
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the two seed-based DataForSEO Labs Google endpoints to /keywords as new tabs alongside Volume. Stacked on PR #18.

## What works after this PR

KeywordsPage now has three tabs:
- Volume (existing): Google Ads search_volume for up to 1000 keywords.
- Suggestions (new): Long-tail keywords containing the seed term. Default limit 200.
- Related (new): Keywords from Googles 'searches related to' section, with a depth slider 1 to 4.

Both Labs tabs use a shared SeedTab base component that handles the input, cost preview, and results table, so future Labs endpoints (keywords_for_site, ranked_keywords) plug in trivially.

## Backend changes (src-tauri/)

- api::labs: typed request/response, single parse_labs_response helper that normalizes suggestions vs related payload nesting. Both go through Family::Labs in the rate-limiter and check the DataForSEO internal status_code.
- commands::keywords::keywords_suggestions and ::keywords_related: command wrappers that call the API and append to the api_calls ledger via a shared record_labs_call helper.
- LabsKeyword / LabsBatch DTOs exported via ts-rs.
- lib.rs: registers the two new commands.

## Frontend changes (src/)

- routes/KeywordsPage.tsx: was a single-purpose form, now a tabbed shell.
- routes/keywords/VolumeTab.tsx: extracted from the old KeywordsPage with no behavioral change.
- routes/keywords/SeedTab.tsx: shared base for any seed-based Labs query (input, cost preview, extra-controls slot, results table).
- routes/keywords/SuggestionsTab.tsx: thin wrapper around SeedTab.
- routes/keywords/RelatedTab.tsx: depth-slider control wired into the cost preview.
- lib/tauri.ts: keywordsSuggestions / keywordsRelated wrappers + types.

## Out of scope, deferred

- keywords_for_site and ranked_keywords (target a domain, not a seed) belong on DomainPage and will land in their own milestone.
- Per-keyword "+volume" quick-action that chains a search_volume call (architecture Teil 10).
- Caching for Labs results: not added in this PR. Suggestions and Related results are short-lived (API generates them at request time) and the value of caching across user sessions is low compared to search_volume.

## Test plan
- [ ] cd apps/dataforseo-app/src-tauri && cargo check (compiles after the new modules).
- [ ] npm run tauri:dev with valid credentials, switch between the three tabs, run a Suggestions and a Related query, verify rows appear and api_calls table records both endpoints.
- [ ] Inspect a related_keywords request manually (small seed, depth=1) and confirm the parser flattens keyword_data correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_