### PR TITLE
FEAT: Tier 1 Milestone 5b - Domain Labs endpoints + DomainPage

### DIFF
--- a/apps/dataforseo-app/src-tauri/src/api/labs.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/labs.rs
@@ -72,6 +72,130 @@ impl ApiClient {
             .await?;
         parse_labs_response(&raw)
     }
+
+    pub async fn labs_keywords_for_site(
+        &self,
+        target: &str,
+        location_code: u32,
+        language_code: &str,
+        limit: u32,
+    ) -> Result<LabsResponse> {
+        let body = serde_json::json!([{
+            "target": target,
+            "location_code": location_code,
+            "language_code": language_code,
+            "limit": limit.min(1000),
+        }]);
+        let raw = self
+            .post_json(
+                Family::Labs,
+                "/v3/dataforseo_labs/google/keywords_for_site/live",
+                &body,
+            )
+            .await?;
+        parse_labs_response(&raw)
+    }
+
+    pub async fn labs_ranked_keywords(
+        &self,
+        target: &str,
+        location_code: u32,
+        language_code: &str,
+        limit: u32,
+    ) -> Result<RankedResponse> {
+        let body = serde_json::json!([{
+            "target": target,
+            "location_code": location_code,
+            "language_code": language_code,
+            "limit": limit.min(1000),
+        }]);
+        let raw = self
+            .post_json(
+                Family::Labs,
+                "/v3/dataforseo_labs/google/ranked_keywords/live",
+                &body,
+            )
+            .await?;
+        parse_ranked_response(&raw)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RankedKeywordItem {
+    pub keyword: String,
+    pub search_volume: Option<i64>,
+    pub competition: Option<String>,
+    pub cpc: Option<f64>,
+    pub keyword_difficulty: Option<i32>,
+    pub rank_absolute: Option<i32>,
+    pub serp_url: Option<String>,
+    pub etv: Option<f64>,
+}
+
+#[derive(Debug)]
+pub struct RankedResponse {
+    pub items: Vec<RankedKeywordItem>,
+    pub cost: f64,
+}
+
+fn parse_ranked_response(raw: &serde_json::Value) -> Result<RankedResponse> {
+    let api_status = raw.pointer("/status_code").and_then(|v| v.as_u64()).unwrap_or(0);
+    if api_status != 20000 {
+        let message = raw
+            .pointer("/status_message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown DataForSEO error");
+        return Err(AppError::Api {
+            status_code: api_status as u32,
+            message: message.into(),
+        });
+    }
+
+    let cost = raw.pointer("/cost").and_then(|v| v.as_f64()).unwrap_or(0.0);
+
+    let raw_items = raw
+        .pointer("/tasks/0/result/0/items")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| AppError::Api {
+            status_code: 20000,
+            message: "ranked_keywords response missing tasks[0].result[0].items".into(),
+        })?;
+
+    let items = raw_items
+        .iter()
+        .filter_map(|raw_item| {
+            let kd = raw_item.pointer("/keyword_data")?;
+            let info = kd.pointer("/keyword_info");
+            let keyword = kd.pointer("/keyword").and_then(|v| v.as_str())?.to_owned();
+            let serp = raw_item.pointer("/ranked_serp_element/serp_item");
+            Some(RankedKeywordItem {
+                keyword,
+                search_volume: info.and_then(|i| i.pointer("/search_volume")).and_then(|v| v.as_i64()),
+                competition: info
+                    .and_then(|i| i.pointer("/competition"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_owned()),
+                cpc: info.and_then(|i| i.pointer("/cpc")).and_then(|v| v.as_f64()),
+                keyword_difficulty: kd
+                    .pointer("/keyword_properties/keyword_difficulty")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n as i32),
+                rank_absolute: serp
+                    .and_then(|s| s.pointer("/rank_absolute"))
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n as i32),
+                serp_url: serp
+                    .and_then(|s| s.pointer("/url"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_owned()),
+                etv: raw_item
+                    .pointer("/ranked_serp_element/serp_item/etv")
+                    .and_then(|v| v.as_f64()),
+            })
+        })
+        .collect();
+
+    Ok(RankedResponse { items, cost })
 }
 
 fn parse_labs_response(raw: &serde_json::Value) -> Result<LabsResponse> {

--- a/apps/dataforseo-app/src-tauri/src/api/labs.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/labs.rs
@@ -156,9 +156,8 @@ fn parse_ranked_response(raw: &serde_json::Value) -> Result<RankedResponse> {
     let raw_items = raw
         .pointer("/tasks/0/result/0/items")
         .and_then(|v| v.as_array())
-        .ok_or_else(|| AppError::Api {
-            status_code: 20000,
-            message: "ranked_keywords response missing tasks[0].result[0].items".into(),
+        .ok_or_else(|| {
+            AppError::Parse("ranked_keywords response missing tasks[0].result[0].items".into())
         })?;
 
     let items = raw_items
@@ -188,9 +187,7 @@ fn parse_ranked_response(raw: &serde_json::Value) -> Result<RankedResponse> {
                     .and_then(|s| s.pointer("/url"))
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_owned()),
-                etv: raw_item
-                    .pointer("/ranked_serp_element/serp_item/etv")
-                    .and_then(|v| v.as_f64()),
+                etv: serp.and_then(|s| s.pointer("/etv")).and_then(|v| v.as_f64()),
             })
         })
         .collect();

--- a/apps/dataforseo-app/src-tauri/src/commands/keywords.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/keywords.rs
@@ -7,7 +7,7 @@ use tokio::task;
 use ts_rs::TS;
 
 use crate::api::keywords_data::SearchVolumeRequest;
-use crate::api::labs::LabsKeywordItem;
+use crate::api::labs::{LabsKeywordItem, RankedKeywordItem};
 use crate::domain::cost::{self, CostAction};
 use crate::domain::types::Mode;
 use crate::errors::Result;
@@ -238,15 +238,123 @@ pub async fn keywords_related(
     })
 }
 
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn keywords_for_domain(
+    state: State<'_, AppState>,
+    target: String,
+    location_code: u32,
+    language_code: String,
+    limit: u32,
+) -> Result<LabsBatch> {
+    let estimated_usd = cost::estimate(&CostAction::KeywordsForDomain { mode: Mode::Live });
+
+    let resp = state
+        .api
+        .labs_keywords_for_site(&target, location_code, &language_code, limit)
+        .await?;
+
+    record_ledger_entry(
+        state.clone(),
+        "labs.keywords_for_site",
+        resp.cost,
+        estimated_usd,
+        resp.items.len() as i64,
+    )
+    .await?;
+
+    Ok(LabsBatch {
+        items: resp.items.into_iter().map(LabsKeyword::from).collect(),
+        cost_usd: resp.cost,
+        estimated_usd,
+    })
+}
+
+#[derive(Debug, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct RankedKeyword {
+    pub keyword: String,
+    pub search_volume: Option<i64>,
+    pub competition: Option<String>,
+    pub cpc: Option<f64>,
+    pub keyword_difficulty: Option<i32>,
+    pub rank_absolute: Option<i32>,
+    pub serp_url: Option<String>,
+    pub etv: Option<f64>,
+}
+
+#[derive(Debug, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct RankedBatch {
+    pub items: Vec<RankedKeyword>,
+    pub cost_usd: f64,
+    pub estimated_usd: f64,
+}
+
+impl From<RankedKeywordItem> for RankedKeyword {
+    fn from(it: RankedKeywordItem) -> Self {
+        Self {
+            keyword: it.keyword,
+            search_volume: it.search_volume,
+            competition: it.competition,
+            cpc: it.cpc,
+            keyword_difficulty: it.keyword_difficulty,
+            rank_absolute: it.rank_absolute,
+            serp_url: it.serp_url,
+            etv: it.etv,
+        }
+    }
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn keywords_ranked(
+    state: State<'_, AppState>,
+    target: String,
+    location_code: u32,
+    language_code: String,
+    limit: u32,
+) -> Result<RankedBatch> {
+    let estimated_usd = cost::estimate(&CostAction::KeywordsForDomain { mode: Mode::Live });
+
+    let resp = state
+        .api
+        .labs_ranked_keywords(&target, location_code, &language_code, limit)
+        .await?;
+
+    record_ledger_entry(
+        state.clone(),
+        "labs.ranked_keywords",
+        resp.cost,
+        estimated_usd,
+        resp.items.len() as i64,
+    )
+    .await?;
+
+    Ok(RankedBatch {
+        items: resp.items.into_iter().map(RankedKeyword::from).collect(),
+        cost_usd: resp.cost,
+        estimated_usd,
+    })
+}
+
 async fn record_labs_call(
     state: State<'_, AppState>,
     endpoint: &'static str,
     resp: &crate::api::labs::LabsResponse,
     estimated_usd: f64,
 ) -> Result<()> {
+    record_ledger_entry(state, endpoint, resp.cost, estimated_usd, resp.items.len() as i64).await
+}
+
+async fn record_ledger_entry(
+    state: State<'_, AppState>,
+    endpoint: &'static str,
+    cost_usd: f64,
+    estimated_usd: f64,
+    items_len: i64,
+) -> Result<()> {
     let store = state.store.clone();
-    let cost = resp.cost;
-    let items_len = resp.items.len() as i64;
     task::spawn_blocking(move || -> Result<()> {
         store.with_conn(|c| {
             ledger::record(
@@ -254,7 +362,7 @@ async fn record_labs_call(
                 &LedgerEntry {
                     endpoint,
                     mode: "live",
-                    cost_usd: cost,
+                    cost_usd,
                     estimated_usd: Some(estimated_usd),
                     request_size: Some(items_len),
                     response_status: Some(20000),

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -34,6 +34,8 @@ pub fn run() {
             commands::keywords::keywords_search_volume,
             commands::keywords::keywords_suggestions,
             commands::keywords::keywords_related,
+            commands::keywords::keywords_for_domain,
+            commands::keywords::keywords_ranked,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -74,4 +74,27 @@ export const tauriApi = {
 
   keywordsRelated: (args: LabsSeedArgs & { depth: number }) =>
     invoke<LabsBatch>("keywords_related", args),
+
+  keywordsForDomain: (args: { target: string; locationCode: number; languageCode: string; limit: number }) =>
+    invoke<LabsBatch>("keywords_for_domain", args),
+
+  keywordsRanked: (args: { target: string; locationCode: number; languageCode: string; limit: number }) =>
+    invoke<RankedBatch>("keywords_ranked", args),
 };
+
+export interface RankedKeyword {
+  keyword: string;
+  search_volume: number | null;
+  competition: string | null;
+  cpc: number | null;
+  keyword_difficulty: number | null;
+  rank_absolute: number | null;
+  serp_url: string | null;
+  etv: number | null;
+}
+
+export interface RankedBatch {
+  items: RankedKeyword[];
+  cost_usd: number;
+  estimated_usd: number;
+}

--- a/apps/dataforseo-app/src/routes/DomainPage.tsx
+++ b/apps/dataforseo-app/src/routes/DomainPage.tsx
@@ -1,10 +1,60 @@
+import { useState } from "react";
+
+import KeywordsForSiteTab from "./domain/KeywordsForSiteTab";
+import RankedKeywordsTab from "./domain/RankedKeywordsTab";
+
+const TABS = [
+  { id: "keywords", label: "Keywords for Domain" },
+  { id: "ranked", label: "Ranked Keywords" },
+] as const;
+
+type TabId = (typeof TABS)[number]["id"];
+
 export default function DomainPage() {
+  const [target, setTarget] = useState("");
+  const [active, setActive] = useState<TabId>("keywords");
+
   return (
-    <section>
-      <h2 className="text-xl font-semibold">Domain</h2>
-      <p className="mt-2 text-sm text-slate-600">
-        Tier 1: ranked_keywords pro Domain + Summary-Tiles.
-      </p>
+    <section className="flex flex-col gap-6">
+      <header>
+        <h2 className="text-xl font-semibold">Domain</h2>
+        <p className="text-sm text-slate-600">
+          Keywords a domain ranks for and the SERP positions it currently holds.
+        </p>
+      </header>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium text-slate-700">Target domain or URL</span>
+        <input
+          type="text"
+          value={target}
+          onChange={(e) => setTarget(e.target.value)}
+          className="rounded border px-2 py-1 font-mono text-sm"
+          placeholder="example.com"
+          spellCheck={false}
+          autoComplete="off"
+        />
+      </label>
+
+      <nav className="flex gap-1 border-b">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActive(tab.id)}
+            className={`-mb-px border-b-2 px-3 py-1.5 text-sm transition-colors ${
+              active === tab.id
+                ? "border-slate-800 font-medium text-slate-800"
+                : "border-transparent text-slate-500 hover:text-slate-700"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
+
+      {active === "keywords" && <KeywordsForSiteTab target={target} />}
+      {active === "ranked" && <RankedKeywordsTab target={target} />}
     </section>
   );
 }

--- a/apps/dataforseo-app/src/routes/domain/KeywordsForSiteTab.tsx
+++ b/apps/dataforseo-app/src/routes/domain/KeywordsForSiteTab.tsx
@@ -1,0 +1,91 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+
+import CostPreview from "../../components/CostPreview";
+import ResultsTable from "../../components/ResultsTable";
+import { formatCount, formatUsd } from "../../lib/format";
+import { tauriApi, type LabsBatch, type LabsKeyword } from "../../lib/tauri";
+
+const DEFAULT_LOCATION = 2276;
+const DEFAULT_LANGUAGE = "de";
+
+interface Props {
+  target: string;
+}
+
+export default function KeywordsForSiteTab({ target }: Props) {
+  const [busy, setBusy] = useState(false);
+  const [batch, setBatch] = useState<LabsBatch | null>(null);
+
+  const trimmed = target.trim();
+
+  const columns = useMemo<ColumnDef<LabsKeyword, unknown>[]>(
+    () => [
+      { header: "Keyword", accessorKey: "keyword", cell: (ctx) => <span className="font-mono">{ctx.getValue<string>()}</span> },
+      { header: "Volume", accessorKey: "search_volume", cell: (ctx) => formatCount(ctx.getValue<number>() ?? 0) },
+      { header: "Competition", accessorKey: "competition" },
+      {
+        header: "CPC",
+        accessorKey: "cpc",
+        cell: (ctx) => {
+          const v = ctx.getValue<number | null>();
+          return v != null ? formatUsd(v) : "—";
+        },
+      },
+      { header: "Difficulty", accessorKey: "keyword_difficulty", cell: (ctx) => ctx.getValue<number | null>() ?? "—" },
+    ],
+    [],
+  );
+
+  async function onRun() {
+    if (!trimmed) return;
+    setBusy(true);
+    try {
+      const result = await tauriApi.keywordsForDomain({
+        target: trimmed,
+        locationCode: DEFAULT_LOCATION,
+        languageCode: DEFAULT_LANGUAGE,
+        limit: 200,
+      });
+      setBatch(result);
+      toast.success(`${result.items.length} keywords (${formatUsd(result.cost_usd)})`);
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-start gap-4">
+        <CostPreview
+          action={{ kind: "KeywordsForDomain", mode: "live" }}
+          details={["Returns keywords related to the target site (Labs DB)."]}
+          disabled={!trimmed || busy}
+        />
+        <button
+          type="button"
+          onClick={onRun}
+          disabled={busy || !trimmed}
+          className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+        >
+          {busy ? "Running…" : "Run"}
+        </button>
+      </div>
+
+      {batch && (
+        <div className="text-xs text-slate-500">
+          {batch.items.length} rows · actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+        </div>
+      )}
+
+      <ResultsTable
+        data={batch?.items ?? []}
+        columns={columns}
+        emptyMessage="Enter a target domain above and click Run."
+      />
+    </div>
+  );
+}

--- a/apps/dataforseo-app/src/routes/domain/RankedKeywordsTab.tsx
+++ b/apps/dataforseo-app/src/routes/domain/RankedKeywordsTab.tsx
@@ -50,12 +50,20 @@ export default function RankedKeywordsTab({ target }: Props) {
         accessorKey: "serp_url",
         cell: (ctx) => {
           const url = ctx.getValue<string | null>();
-          return url ? (
+          if (!url) return "—";
+          // The API can occasionally return non-absolute URLs (e.g., for
+          // certain SERP feature types) that crash new URL(). Fall back
+          // to the raw string so the row keeps rendering.
+          let display: string;
+          try {
+            display = new URL(url).pathname || url;
+          } catch {
+            display = url;
+          }
+          return (
             <a href={url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
-              {new URL(url).pathname || url}
+              {display}
             </a>
-          ) : (
-            "—"
           );
         },
       },

--- a/apps/dataforseo-app/src/routes/domain/RankedKeywordsTab.tsx
+++ b/apps/dataforseo-app/src/routes/domain/RankedKeywordsTab.tsx
@@ -1,0 +1,116 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+
+import CostPreview from "../../components/CostPreview";
+import ResultsTable from "../../components/ResultsTable";
+import { formatCount, formatUsd } from "../../lib/format";
+import { tauriApi, type RankedBatch, type RankedKeyword } from "../../lib/tauri";
+
+const DEFAULT_LOCATION = 2276;
+const DEFAULT_LANGUAGE = "de";
+
+interface Props {
+  target: string;
+}
+
+export default function RankedKeywordsTab({ target }: Props) {
+  const [busy, setBusy] = useState(false);
+  const [batch, setBatch] = useState<RankedBatch | null>(null);
+
+  const trimmed = target.trim();
+
+  const columns = useMemo<ColumnDef<RankedKeyword, unknown>[]>(
+    () => [
+      {
+        header: "Position",
+        accessorKey: "rank_absolute",
+        cell: (ctx) => ctx.getValue<number | null>() ?? "—",
+      },
+      {
+        header: "Keyword",
+        accessorKey: "keyword",
+        cell: (ctx) => <span className="font-mono">{ctx.getValue<string>()}</span>,
+      },
+      {
+        header: "Volume",
+        accessorKey: "search_volume",
+        cell: (ctx) => formatCount(ctx.getValue<number>() ?? 0),
+      },
+      {
+        header: "ETV",
+        accessorKey: "etv",
+        cell: (ctx) => {
+          const v = ctx.getValue<number | null>();
+          return v != null ? formatCount(v) : "—";
+        },
+      },
+      {
+        header: "URL",
+        accessorKey: "serp_url",
+        cell: (ctx) => {
+          const url = ctx.getValue<string | null>();
+          return url ? (
+            <a href={url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+              {new URL(url).pathname || url}
+            </a>
+          ) : (
+            "—"
+          );
+        },
+      },
+    ],
+    [],
+  );
+
+  async function onRun() {
+    if (!trimmed) return;
+    setBusy(true);
+    try {
+      const result = await tauriApi.keywordsRanked({
+        target: trimmed,
+        locationCode: DEFAULT_LOCATION,
+        languageCode: DEFAULT_LANGUAGE,
+        limit: 200,
+      });
+      setBatch(result);
+      toast.success(`${result.items.length} ranked keywords (${formatUsd(result.cost_usd)})`);
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-start gap-4">
+        <CostPreview
+          action={{ kind: "KeywordsForDomain", mode: "live" }}
+          details={["Keywords for which the target ranks in Google, with SERP positions."]}
+          disabled={!trimmed || busy}
+        />
+        <button
+          type="button"
+          onClick={onRun}
+          disabled={busy || !trimmed}
+          className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+        >
+          {busy ? "Running…" : "Run"}
+        </button>
+      </div>
+
+      {batch && (
+        <div className="text-xs text-slate-500">
+          {batch.items.length} ranked keywords · actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+        </div>
+      )}
+
+      <ResultsTable
+        data={batch?.items ?? []}
+        columns={columns}
+        emptyMessage="Enter a target domain above and click Run."
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the two domain-targeted DataForSEO Labs Google endpoints and turns the placeholder DomainPage into a working tabbed UI. Stacked on PR #19.

This closes the four-endpoint Labs Google scope from architecture Teil 14 milestones 4 and 5: Suggestions, Related, ForDomain, Ranked.

## What works after this PR

DomainPage now has a shared target-domain input and two tabs:
- Keywords for Domain (keywords_for_site): keyword ideas the target site is associated with in the Labs DB.
- Ranked Keywords (ranked_keywords): keywords the target currently ranks for, with absolute SERP position, ETV, and the result URL.

## Backend changes (src-tauri/)

- api::labs::labs_keywords_for_site: same response shape as suggestions / related, takes a target domain.
- api::labs::labs_ranked_keywords: returns RankedKeywordItem with rank_absolute, serp_url, etv from the ranked_serp_element nesting.
- commands::keywords::keywords_for_domain and ::keywords_ranked: thin command wrappers.
- record_ledger_entry: extracted helper, replaces record_labs_call so all four Labs commands now share the same ledger-write path.
- lib.rs: registers the two new commands.

## Frontend changes (src/)

- routes/DomainPage.tsx: shared target-domain input + two tabs.
- routes/domain/KeywordsForSiteTab.tsx and RankedKeywordsTab.tsx: per-tab UI.
- lib/tauri.ts: keywordsForDomain / keywordsRanked wrappers, RankedKeyword / RankedBatch types.

## Out of scope, deferred

- Caching for ranked_keywords / keywords_for_site (positions are user-time-sensitive; caching adds little value).
- The ranked-keywords-style "+ track this keyword" quick-action that would feed into a future rank-tracking feature.

## Test plan
- [ ] cd apps/dataforseo-app/src-tauri && cargo check (compiles after the new modules).
- [ ] npm run tauri:dev with valid credentials, navigate to /domain, enter a known-ranking domain, run both tabs, confirm rows appear and the api_calls table records labs.keywords_for_site and labs.ranked_keywords entries.
- [ ] Confirm the SERP-URL link in the Ranked tab opens in the system browser (Tauri shell plugin).


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_