### PR TITLE
FEAT: Tier 1 Milestone 7 - SERP Standard Queue task pipeline

### DIFF
--- a/apps/dataforseo-app/src-tauri/src/api/client.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/client.rs
@@ -63,6 +63,24 @@ impl ApiClient {
         Self::deserialize_or_err(resp).await
     }
 
+    /// GET a path and return the parsed response, gated by the rate limiter
+    /// for the given family. Used by tasks_ready / task_get.
+    pub(crate) async fn get_json(
+        &self,
+        family: Family,
+        path: &str,
+    ) -> Result<serde_json::Value> {
+        self.scheduler.acquire(family).await;
+        let creds = self.credentials().await?;
+        let resp = self
+            .http
+            .get(format!("{BASE_URL}{path}"))
+            .basic_auth(&creds.login, Some(&creds.password))
+            .send()
+            .await?;
+        Self::deserialize_or_err(resp).await
+    }
+
     async fn deserialize_or_err(resp: reqwest::Response) -> Result<serde_json::Value> {
         let status = resp.status();
         if !status.is_success() {

--- a/apps/dataforseo-app/src-tauri/src/api/serp.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/serp.rs
@@ -1,8 +1,7 @@
 //! SERP API — Google Organic.
 //!
-//! Tier 1 covers the Live "regular" variant (cheapest, returns the basic
-//! item types). The "advanced" variant and the standard-queue task flow
-//! land in later milestones.
+//! Live "regular" + the Standard-Queue task flow (task_post / tasks_ready /
+//! task_get/regular). The "advanced" variant lands in a later milestone.
 
 use serde::Deserialize;
 
@@ -91,4 +90,140 @@ impl ApiClient {
             cost,
         })
     }
+
+    /// Submit a batch of SERP tasks to the Standard Queue. Each entry in
+    /// `keywords` becomes one task with the same location/language/depth.
+    /// Returns the DataForSEO-assigned task_ids in the same order.
+    pub async fn serp_google_organic_task_post(
+        &self,
+        keywords: &[String],
+        location_code: u32,
+        language_code: &str,
+        depth: u32,
+    ) -> Result<TaskPostResponse> {
+        let entries: Vec<serde_json::Value> = keywords
+            .iter()
+            .map(|k| {
+                serde_json::json!({
+                    "keyword": k,
+                    "location_code": location_code,
+                    "language_code": language_code,
+                    "depth": depth.clamp(10, 100),
+                })
+            })
+            .collect();
+        let body = serde_json::Value::Array(entries);
+
+        let raw = self
+            .post_json(
+                Family::SerpTask,
+                "/v3/serp/google/organic/task_post",
+                &body,
+            )
+            .await?;
+
+        let api_status = raw.pointer("/status_code").and_then(|v| v.as_u64()).unwrap_or(0);
+        if api_status != 20000 {
+            let message = raw
+                .pointer("/status_message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown DataForSEO error");
+            return Err(AppError::Api {
+                status_code: api_status as u32,
+                message: message.into(),
+            });
+        }
+
+        let cost = raw.pointer("/cost").and_then(|v| v.as_f64()).unwrap_or(0.0);
+
+        let task_ids = raw
+            .pointer("/tasks")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| AppError::Parse("task_post response missing tasks array".into()))?
+            .iter()
+            .filter_map(|t| t.pointer("/id").and_then(|v| v.as_str()).map(|s| s.to_owned()))
+            .collect();
+
+        Ok(TaskPostResponse { task_ids, cost })
+    }
+
+    /// Returns the task_ids that have completed and are ready to fetch.
+    pub async fn serp_google_organic_tasks_ready(&self) -> Result<Vec<String>> {
+        let raw = self
+            .get_json(Family::SerpTask, "/v3/serp/google/organic/tasks_ready")
+            .await?;
+
+        let api_status = raw.pointer("/status_code").and_then(|v| v.as_u64()).unwrap_or(0);
+        if api_status != 20000 {
+            let message = raw
+                .pointer("/status_message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown DataForSEO error");
+            return Err(AppError::Api {
+                status_code: api_status as u32,
+                message: message.into(),
+            });
+        }
+
+        let ids = raw
+            .pointer("/tasks/0/result")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| t.pointer("/id").and_then(|v| v.as_str()).map(|s| s.to_owned()))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        Ok(ids)
+    }
+
+    /// Fetch the regular result set for a single completed task.
+    pub async fn serp_google_organic_task_get_regular(
+        &self,
+        task_id: &str,
+    ) -> Result<SerpLiveResponse> {
+        let path = format!("/v3/serp/google/organic/task_get/regular/{task_id}");
+        let raw = self.get_json(Family::SerpTask, &path).await?;
+
+        let api_status = raw.pointer("/status_code").and_then(|v| v.as_u64()).unwrap_or(0);
+        if api_status != 20000 {
+            let message = raw
+                .pointer("/status_message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown DataForSEO error");
+            return Err(AppError::Api {
+                status_code: api_status as u32,
+                message: message.into(),
+            });
+        }
+
+        let cost = raw.pointer("/cost").and_then(|v| v.as_f64()).unwrap_or(0.0);
+
+        let result = raw
+            .pointer("/tasks/0/result/0")
+            .ok_or_else(|| AppError::Parse("task_get response missing tasks[0].result[0]".into()))?;
+
+        let keyword_out = result
+            .pointer("/keyword")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_owned();
+
+        let items = result
+            .pointer("/items")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| AppError::Parse("task_get response missing items array".into()))?
+            .iter()
+            .filter_map(|raw| serde_json::from_value::<SerpItem>(raw.clone()).ok())
+            .collect();
+
+        Ok(SerpLiveResponse { keyword: keyword_out, items, cost })
+    }
+}
+
+#[derive(Debug)]
+pub struct TaskPostResponse {
+    pub task_ids: Vec<String>,
+    pub cost: f64,
 }

--- a/apps/dataforseo-app/src-tauri/src/commands/serp.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/serp.rs
@@ -153,9 +153,11 @@ pub async fn serp_task_create(
         .serp_google_organic_task_post(&cleaned, location_code, &language_code, depth)
         .await?;
 
+    // Millisecond precision so two batches submitted in the same second
+    // do not collide on batch_id (the primary group key in serp_tasks).
     let batch_id = format!(
         "batch-{}",
-        chrono::Utc::now().format("%Y%m%dT%H%M%SZ")
+        chrono::Utc::now().format("%Y%m%dT%H%M%S%.3fZ")
     );
 
     let store = state.store.clone();
@@ -168,33 +170,51 @@ pub async fn serp_task_create(
 
     task::spawn_blocking(move || -> Result<()> {
         store.with_conn(|c| {
-            for (idx, task_id) in task_ids.iter().enumerate() {
-                if let Some(kw) = kws.get(idx) {
-                    crate::store::serp_tasks::insert_pending(
-                        c,
-                        task_id,
-                        &bid,
-                        kw,
-                        location_code,
-                        &lang,
-                        depth,
-                    )?;
+            // Wrap the insert_pending loop + ledger row in one transaction:
+            // DuckDB autocommits per-statement otherwise, which is slow and
+            // leaves a window where some tasks are persisted but the ledger
+            // row is missing if the process dies mid-batch.
+            let tx = c.transaction()?;
+            {
+                let mut insert_task = tx.prepare(
+                    "INSERT INTO serp_tasks
+                        (task_id, batch_id, keyword, location_code, language_code, depth,
+                         status, poll_attempts)
+                     VALUES ($1, $2, $3, $4, $5, $6, 'pending', 0)
+                     ON CONFLICT (task_id) DO NOTHING",
+                )?;
+                for (idx, task_id) in task_ids.iter().enumerate() {
+                    if let Some(kw) = kws.get(idx) {
+                        insert_task.execute(duckdb::params![
+                            task_id,
+                            &bid,
+                            kw,
+                            location_code as i64,
+                            &lang,
+                            depth as i64,
+                        ])?;
+                    }
                 }
             }
-            ledger::record(
-                c,
-                &LedgerEntry {
-                    endpoint: "serp.google.organic.task_post",
-                    mode: "standard",
-                    cost_usd: api_cost,
-                    estimated_usd: Some(estimated_usd),
-                    request_size: Some(request_size),
-                    response_status: Some(20000),
-                    duration_ms: None,
-                    task_id: None,
-                    error: None,
-                },
-            )
+            tx.execute(
+                "INSERT INTO api_calls
+                    (endpoint, mode, cost_usd, estimated_usd, request_size,
+                     response_status, duration_ms, task_id, error)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                duckdb::params![
+                    "serp.google.organic.task_post",
+                    "standard",
+                    api_cost,
+                    Some(estimated_usd),
+                    Some(request_size),
+                    Some(20000_i64),
+                    None::<i64>,
+                    None::<&str>,
+                    None::<&str>,
+                ],
+            )?;
+            tx.commit()?;
+            Ok(())
         })
     })
     .await
@@ -219,14 +239,13 @@ pub async fn serp_task_status(
     let (tasks, results) = task::spawn_blocking(move || -> Result<_> {
         store.with_conn(|c| {
             let tasks = crate::store::serp_tasks::list_batch(c, &bid)?;
-            let mut results = std::collections::HashMap::new();
-            for t in &tasks {
-                if t.status == "fetched" {
-                    let items = crate::store::serp_results::list_for_task(c, &t.task_id)?;
-                    if !items.is_empty() {
-                        results.insert(t.task_id.clone(), items);
-                    }
-                }
+            // Single JOIN-backed query for every result row in this batch,
+            // grouped in Rust afterward. Was N+1: one list_for_task per task.
+            let all_items = crate::store::serp_results::list_for_batch(c, &bid)?;
+            let mut results: std::collections::HashMap<String, Vec<_>> =
+                std::collections::HashMap::new();
+            for item in all_items {
+                results.entry(item.task_id.clone()).or_default().push(item);
             }
             Ok((tasks, results))
         })

--- a/apps/dataforseo-app/src-tauri/src/commands/serp.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/serp.rs
@@ -97,3 +97,156 @@ pub async fn serp_live(
         estimated_usd,
     })
 }
+
+#[derive(Debug, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct TaskBatchId {
+    pub batch_id: String,
+    pub task_count: u32,
+    pub cost_usd: f64,
+    pub estimated_usd: f64,
+}
+
+#[derive(Debug, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct TaskBatchStatus {
+    pub batch_id: String,
+    pub tasks: Vec<crate::store::serp_tasks::SerpTask>,
+    pub results: std::collections::HashMap<String, Vec<crate::store::serp_results::StoredSerpItem>>,
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn serp_task_create(
+    state: State<'_, AppState>,
+    keywords: Vec<String>,
+    location_code: u32,
+    language_code: String,
+    depth: u32,
+) -> Result<TaskBatchId> {
+    let cleaned: Vec<String> = keywords
+        .into_iter()
+        .map(|k| k.trim().to_owned())
+        .filter(|k| !k.is_empty())
+        .collect();
+
+    if cleaned.is_empty() {
+        return Err(crate::errors::AppError::Validation(
+            "at least one keyword required".into(),
+        ));
+    }
+    if cleaned.len() > 100 {
+        return Err(crate::errors::AppError::Validation(
+            "task_create accepts at most 100 keywords per batch".into(),
+        ));
+    }
+
+    let estimated_usd = cost::estimate(&CostAction::Serp {
+        count: cleaned.len() as u32,
+        mode: Mode::Standard,
+        depth,
+        extra_params: 0,
+    });
+
+    let resp = state
+        .api
+        .serp_google_organic_task_post(&cleaned, location_code, &language_code, depth)
+        .await?;
+
+    let batch_id = format!(
+        "batch-{}",
+        chrono::Utc::now().format("%Y%m%dT%H%M%SZ")
+    );
+
+    let store = state.store.clone();
+    let task_ids = resp.task_ids.clone();
+    let api_cost = resp.cost;
+    let lang = language_code.clone();
+    let kws = cleaned.clone();
+    let bid = batch_id.clone();
+    let request_size = cleaned.len() as i64;
+
+    task::spawn_blocking(move || -> Result<()> {
+        store.with_conn(|c| {
+            for (idx, task_id) in task_ids.iter().enumerate() {
+                if let Some(kw) = kws.get(idx) {
+                    crate::store::serp_tasks::insert_pending(
+                        c,
+                        task_id,
+                        &bid,
+                        kw,
+                        location_code,
+                        &lang,
+                        depth,
+                    )?;
+                }
+            }
+            ledger::record(
+                c,
+                &LedgerEntry {
+                    endpoint: "serp.google.organic.task_post",
+                    mode: "standard",
+                    cost_usd: api_cost,
+                    estimated_usd: Some(estimated_usd),
+                    request_size: Some(request_size),
+                    response_status: Some(20000),
+                    duration_ms: None,
+                    task_id: None,
+                    error: None,
+                },
+            )
+        })
+    })
+    .await
+    .map_err(|e| crate::errors::AppError::Internal(e.to_string()))??;
+
+    Ok(TaskBatchId {
+        batch_id,
+        task_count: resp.task_ids.len() as u32,
+        cost_usd: resp.cost,
+        estimated_usd,
+    })
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn serp_task_status(
+    state: State<'_, AppState>,
+    batch_id: String,
+) -> Result<TaskBatchStatus> {
+    let store = state.store.clone();
+    let bid = batch_id.clone();
+    let (tasks, results) = task::spawn_blocking(move || -> Result<_> {
+        store.with_conn(|c| {
+            let tasks = crate::store::serp_tasks::list_batch(c, &bid)?;
+            let mut results = std::collections::HashMap::new();
+            for t in &tasks {
+                if t.status == "fetched" {
+                    let items = crate::store::serp_results::list_for_task(c, &t.task_id)?;
+                    if !items.is_empty() {
+                        results.insert(t.task_id.clone(), items);
+                    }
+                }
+            }
+            Ok((tasks, results))
+        })
+    })
+    .await
+    .map_err(|e| crate::errors::AppError::Internal(e.to_string()))??;
+
+    Ok(TaskBatchStatus { batch_id, tasks, results })
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn serp_task_recent_batches(
+    state: State<'_, AppState>,
+    limit: u32,
+) -> Result<Vec<crate::store::serp_tasks::BatchSummary>> {
+    let store = state.store.clone();
+    task::spawn_blocking(move || -> Result<_> {
+        store.with_conn(|c| crate::store::serp_tasks::list_recent_batches(c, limit))
+    })
+    .await
+    .map_err(|e| crate::errors::AppError::Internal(e.to_string()))?
+}

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -23,7 +23,13 @@ pub fn run() {
                 .app_local_data_dir()
                 .expect("app_local_data_dir resolves on supported platforms");
             let db_path = dir.join("dataforseo-app.duckdb");
-            app.manage(AppState::new(db_path));
+            let state = AppState::new(db_path);
+            let api = state.api.clone();
+            let store = state.store.clone();
+            app.manage(state);
+            tauri::async_runtime::spawn(async move {
+                tasks::poller::run(api, store).await;
+            });
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
@@ -37,6 +43,9 @@ pub fn run() {
             commands::keywords::keywords_for_domain,
             commands::keywords::keywords_ranked,
             commands::serp::serp_live,
+            commands::serp::serp_task_create,
+            commands::serp::serp_task_status,
+            commands::serp::serp_task_recent_batches,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/dataforseo-app/src-tauri/src/store/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/mod.rs
@@ -1,6 +1,8 @@
 pub mod keywords_cache;
 pub mod ledger;
 pub mod schema;
+pub mod serp_results;
+pub mod serp_tasks;
 
 use std::path::PathBuf;
 use std::sync::Mutex;

--- a/apps/dataforseo-app/src-tauri/src/store/serp_results.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/serp_results.rs
@@ -58,17 +58,38 @@ pub fn list_for_task(conn: &mut Connection, task_id: &str) -> Result<Vec<StoredS
           WHERE task_id = $1
           ORDER BY position",
     )?;
-    let rows = stmt.query_map([task_id], |row| {
-        Ok(StoredSerpItem {
-            task_id: row.get(0)?,
-            position: row.get::<_, i64>(1)? as i32,
-            kind: row.get(2)?,
-            url: row.get(3)?,
-            title: row.get(4)?,
-            description: row.get(5)?,
-            domain: row.get(6)?,
-        })
-    })?;
+    collect(stmt.query_map([task_id], row_to_item)?)
+}
+
+/// Fetch every result row for a batch in one query — avoids the N+1
+/// pattern of calling list_for_task per task in a batch.
+pub fn list_for_batch(conn: &mut Connection, batch_id: &str) -> Result<Vec<StoredSerpItem>> {
+    let mut stmt = conn.prepare(
+        "SELECT r.task_id, r.position, r.type, r.url, r.title, r.description, r.domain
+           FROM serp_results r
+           JOIN serp_tasks t ON t.task_id = r.task_id
+          WHERE t.batch_id = $1
+          ORDER BY r.task_id, r.position",
+    )?;
+    collect(stmt.query_map([batch_id], row_to_item)?)
+}
+
+fn row_to_item(row: &duckdb::Row<'_>) -> duckdb::Result<StoredSerpItem> {
+    Ok(StoredSerpItem {
+        task_id: row.get(0)?,
+        position: row.get::<_, i64>(1)? as i32,
+        kind: row.get(2)?,
+        url: row.get(3)?,
+        title: row.get(4)?,
+        description: row.get(5)?,
+        domain: row.get(6)?,
+    })
+}
+
+fn collect<I>(rows: I) -> Result<Vec<StoredSerpItem>>
+where
+    I: Iterator<Item = duckdb::Result<StoredSerpItem>>,
+{
     let mut out = Vec::new();
     for r in rows {
         out.push(r?);

--- a/apps/dataforseo-app/src-tauri/src/store/serp_results.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/serp_results.rs
@@ -1,0 +1,77 @@
+use duckdb::{params, Connection};
+use serde::Serialize;
+use ts_rs::TS;
+
+use crate::api::serp::SerpItem;
+use crate::errors::Result;
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct StoredSerpItem {
+    pub task_id: String,
+    pub position: i32,
+    pub kind: String,
+    pub url: Option<String>,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub domain: Option<String>,
+}
+
+pub fn insert_batch(conn: &mut Connection, task_id: &str, items: &[SerpItem]) -> Result<()> {
+    if items.is_empty() {
+        return Ok(());
+    }
+    let tx = conn.transaction()?;
+    {
+        let mut stmt = tx.prepare(
+            "INSERT INTO serp_results
+                (task_id, position, type, url, title, description, domain)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             ON CONFLICT (task_id, position) DO UPDATE SET
+                type = excluded.type,
+                url = excluded.url,
+                title = excluded.title,
+                description = excluded.description,
+                domain = excluded.domain",
+        )?;
+        for (idx, item) in items.iter().enumerate() {
+            let position = item.rank_absolute.unwrap_or(idx as i32 + 1) as i64;
+            stmt.execute(params![
+                task_id,
+                position,
+                &item.kind,
+                &item.url,
+                &item.title,
+                &item.description,
+                &item.domain,
+            ])?;
+        }
+    }
+    tx.commit()?;
+    Ok(())
+}
+
+pub fn list_for_task(conn: &mut Connection, task_id: &str) -> Result<Vec<StoredSerpItem>> {
+    let mut stmt = conn.prepare(
+        "SELECT task_id, position, type, url, title, description, domain
+           FROM serp_results
+          WHERE task_id = $1
+          ORDER BY position",
+    )?;
+    let rows = stmt.query_map([task_id], |row| {
+        Ok(StoredSerpItem {
+            task_id: row.get(0)?,
+            position: row.get::<_, i64>(1)? as i32,
+            kind: row.get(2)?,
+            url: row.get(3)?,
+            title: row.get(4)?,
+            description: row.get(5)?,
+            domain: row.get(6)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}

--- a/apps/dataforseo-app/src-tauri/src/store/serp_tasks.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/serp_tasks.rs
@@ -1,0 +1,189 @@
+//! Persistent SERP-Task tracking.
+//!
+//! Source: docs/DATAFORSEO_ARCHITECTURE.md Teil 7. Tasks created by
+//! task_post are persisted with status='pending'; the background poller
+//! transitions them through 'ready' to 'fetched' (or 'failed').
+
+use duckdb::{params, Connection};
+use serde::Serialize;
+use ts_rs::TS;
+
+use crate::errors::Result;
+
+const FAIL_AFTER_ATTEMPTS: i32 = 48; // 48 polls * 30s = 24h ceiling
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct SerpTask {
+    pub task_id: String,
+    pub batch_id: String,
+    pub keyword: String,
+    pub location_code: i32,
+    pub language_code: String,
+    pub depth: i32,
+    pub status: String,
+    pub posted_at: Option<String>,
+    pub fetched_at: Option<String>,
+    pub poll_attempts: i32,
+    pub cost_usd: Option<f64>,
+    pub error: Option<String>,
+}
+
+pub fn insert_pending(
+    conn: &mut Connection,
+    task_id: &str,
+    batch_id: &str,
+    keyword: &str,
+    location_code: u32,
+    language_code: &str,
+    depth: u32,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO serp_tasks
+            (task_id, batch_id, keyword, location_code, language_code, depth,
+             status, poll_attempts)
+         VALUES ($1, $2, $3, $4, $5, $6, 'pending', 0)
+         ON CONFLICT (task_id) DO NOTHING",
+        params![task_id, batch_id, keyword, location_code as i64, language_code, depth as i64],
+    )?;
+    Ok(())
+}
+
+pub fn find_pending(conn: &mut Connection) -> Result<Vec<SerpTask>> {
+    fetch(conn, "WHERE status = 'pending'")
+}
+
+pub fn find_ready(conn: &mut Connection) -> Result<Vec<SerpTask>> {
+    fetch(conn, "WHERE status = 'ready'")
+}
+
+pub fn list_batch(conn: &mut Connection, batch_id: &str) -> Result<Vec<SerpTask>> {
+    let sql = format!(
+        "SELECT task_id, batch_id, keyword, location_code, language_code, depth,
+                status, posted_at, fetched_at, poll_attempts, cost_usd, error
+           FROM serp_tasks
+          WHERE batch_id = $1
+          ORDER BY posted_at"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([batch_id], row_to_task)?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+pub fn list_recent_batches(conn: &mut Connection, limit: u32) -> Result<Vec<BatchSummary>> {
+    let mut stmt = conn.prepare(
+        "SELECT batch_id,
+                COUNT(*) AS total,
+                SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) AS pending,
+                SUM(CASE WHEN status = 'ready'   THEN 1 ELSE 0 END) AS ready,
+                SUM(CASE WHEN status = 'fetched' THEN 1 ELSE 0 END) AS fetched,
+                SUM(CASE WHEN status = 'failed'  THEN 1 ELSE 0 END) AS failed,
+                MIN(posted_at) AS posted_at
+           FROM serp_tasks
+          GROUP BY batch_id
+          ORDER BY posted_at DESC
+          LIMIT $1",
+    )?;
+    let rows = stmt.query_map([limit as i64], |row| {
+        Ok(BatchSummary {
+            batch_id: row.get(0)?,
+            total: row.get::<_, i64>(1)? as i32,
+            pending: row.get::<_, i64>(2)? as i32,
+            ready: row.get::<_, i64>(3)? as i32,
+            fetched: row.get::<_, i64>(4)? as i32,
+            failed: row.get::<_, i64>(5)? as i32,
+            posted_at: row.get::<_, Option<String>>(6)?,
+        })
+    })?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+pub fn mark_ready(conn: &mut Connection, task_id: &str) -> Result<()> {
+    conn.execute(
+        "UPDATE serp_tasks
+            SET status = 'ready', last_polled_at = CURRENT_TIMESTAMP
+          WHERE task_id = $1 AND status = 'pending'",
+        params![task_id],
+    )?;
+    Ok(())
+}
+
+pub fn mark_fetched(conn: &mut Connection, task_id: &str, cost_usd: f64) -> Result<()> {
+    conn.execute(
+        "UPDATE serp_tasks
+            SET status = 'fetched',
+                fetched_at = CURRENT_TIMESTAMP,
+                cost_usd = $2
+          WHERE task_id = $1",
+        params![task_id, cost_usd],
+    )?;
+    Ok(())
+}
+
+pub fn record_attempt(conn: &mut Connection, task_id: &str, error: Option<&str>) -> Result<()> {
+    conn.execute(
+        "UPDATE serp_tasks
+            SET poll_attempts = poll_attempts + 1,
+                last_polled_at = CURRENT_TIMESTAMP,
+                status = CASE
+                    WHEN poll_attempts + 1 >= $2 THEN 'failed'
+                    ELSE status
+                END,
+                error = COALESCE($3, error)
+          WHERE task_id = $1",
+        params![task_id, FAIL_AFTER_ATTEMPTS as i64, error],
+    )?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct BatchSummary {
+    pub batch_id: String,
+    pub total: i32,
+    pub pending: i32,
+    pub ready: i32,
+    pub fetched: i32,
+    pub failed: i32,
+    pub posted_at: Option<String>,
+}
+
+fn fetch(conn: &mut Connection, where_clause: &str) -> Result<Vec<SerpTask>> {
+    let sql = format!(
+        "SELECT task_id, batch_id, keyword, location_code, language_code, depth,
+                status, posted_at, fetched_at, poll_attempts, cost_usd, error
+           FROM serp_tasks {where_clause}"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], row_to_task)?;
+    let mut out = Vec::new();
+    for r in rows {
+        out.push(r?);
+    }
+    Ok(out)
+}
+
+fn row_to_task(row: &duckdb::Row<'_>) -> duckdb::Result<SerpTask> {
+    Ok(SerpTask {
+        task_id: row.get(0)?,
+        batch_id: row.get(1)?,
+        keyword: row.get(2)?,
+        location_code: row.get::<_, i64>(3)? as i32,
+        language_code: row.get(4)?,
+        depth: row.get::<_, i64>(5)? as i32,
+        status: row.get(6)?,
+        posted_at: row.get(7)?,
+        fetched_at: row.get(8)?,
+        poll_attempts: row.get::<_, i64>(9)? as i32,
+        cost_usd: row.get(10)?,
+        error: row.get(11)?,
+    })
+}

--- a/apps/dataforseo-app/src-tauri/src/tasks/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/tasks/mod.rs
@@ -1,2 +1,1 @@
-// TODO Tier 1: Background poller for SERP standard-queue tasks.
-// See docs/DATAFORSEO_ARCHITECTURE.md Teil 7.
+pub mod poller;

--- a/apps/dataforseo-app/src-tauri/src/tasks/poller.rs
+++ b/apps/dataforseo-app/src-tauri/src/tasks/poller.rs
@@ -27,20 +27,22 @@ pub async fn run(api: Arc<ApiClient>, store: Arc<Store>) {
 }
 
 async fn poll_once(api: &Arc<ApiClient>, store: &Arc<Store>) -> Result<()> {
+    // Pending: ask DataForSEO which of our outstanding tasks finished, mark
+    // matches as 'ready'. Skip the network round-trip when we have nothing
+    // outstanding, but still process anything already in 'ready' below —
+    // a previous tick may have marked them ready and then failed to fetch.
     let pending = blocking(store, |c| serp_tasks::find_pending(c)).await?;
-    if pending.is_empty() {
-        return Ok(());
-    }
-
-    let ready_ids = api.serp_google_organic_tasks_ready().await?;
-    if !ready_ids.is_empty() {
-        blocking(store, move |c| {
-            for id in &ready_ids {
-                serp_tasks::mark_ready(c, id)?;
-            }
-            Ok(())
-        })
-        .await?;
+    if !pending.is_empty() {
+        let ready_ids = api.serp_google_organic_tasks_ready().await?;
+        if !ready_ids.is_empty() {
+            blocking(store, move |c| {
+                for id in &ready_ids {
+                    serp_tasks::mark_ready(c, id)?;
+                }
+                Ok(())
+            })
+            .await?;
+        }
     }
 
     let ready = blocking(store, |c| serp_tasks::find_ready(c)).await?;

--- a/apps/dataforseo-app/src-tauri/src/tasks/poller.rs
+++ b/apps/dataforseo-app/src-tauri/src/tasks/poller.rs
@@ -1,0 +1,83 @@
+//! Background poller for SERP standard-queue tasks.
+//!
+//! Source: docs/DATAFORSEO_ARCHITECTURE.md Teil 7. Spawned once at app
+//! startup; on each tick it advances pending tasks to 'ready' (via
+//! /tasks_ready) and fetches results for ready tasks.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::task;
+use tokio::time;
+
+use crate::api::client::ApiClient;
+use crate::errors::{AppError, Result};
+use crate::store::{serp_results, serp_tasks, Store};
+
+const POLL_INTERVAL_SECS: u64 = 30;
+
+pub async fn run(api: Arc<ApiClient>, store: Arc<Store>) {
+    tracing::info!("serp task poller started (interval {}s)", POLL_INTERVAL_SECS);
+    loop {
+        time::sleep(Duration::from_secs(POLL_INTERVAL_SECS)).await;
+        if let Err(e) = poll_once(&api, &store).await {
+            tracing::warn!(error = %e, "serp poller iteration failed");
+        }
+    }
+}
+
+async fn poll_once(api: &Arc<ApiClient>, store: &Arc<Store>) -> Result<()> {
+    let pending = blocking(store, |c| serp_tasks::find_pending(c)).await?;
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    let ready_ids = api.serp_google_organic_tasks_ready().await?;
+    if !ready_ids.is_empty() {
+        blocking(store, move |c| {
+            for id in &ready_ids {
+                serp_tasks::mark_ready(c, id)?;
+            }
+            Ok(())
+        })
+        .await?;
+    }
+
+    let ready = blocking(store, |c| serp_tasks::find_ready(c)).await?;
+    for task in ready {
+        match api.serp_google_organic_task_get_regular(&task.task_id).await {
+            Ok(resp) => {
+                let task_id = task.task_id.clone();
+                let cost = resp.cost;
+                blocking(store, move |c| {
+                    serp_results::insert_batch(c, &task_id, &resp.items)?;
+                    serp_tasks::mark_fetched(c, &task_id, cost)?;
+                    Ok(())
+                })
+                .await?;
+            }
+            Err(e) => {
+                tracing::warn!(task_id = %task.task_id, error = %e, "task_get failed");
+                let task_id = task.task_id.clone();
+                let msg = e.to_string();
+                blocking(store, move |c| {
+                    serp_tasks::record_attempt(c, &task_id, Some(&msg))
+                })
+                .await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn blocking<T, F>(store: &Arc<Store>, f: F) -> Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce(&mut duckdb::Connection) -> Result<T> + Send + 'static,
+{
+    let store = store.clone();
+    task::spawn_blocking(move || store.with_conn(f))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -83,7 +83,68 @@ export const tauriApi = {
 
   serpLive: (args: { keyword: string; locationCode: number; languageCode: string; depth: number }) =>
     invoke<SerpLiveBatch>("serp_live", args),
+
+  serpTaskCreate: (args: {
+    keywords: string[];
+    locationCode: number;
+    languageCode: string;
+    depth: number;
+  }) => invoke<TaskBatchId>("serp_task_create", args),
+
+  serpTaskStatus: (args: { batchId: string }) =>
+    invoke<TaskBatchStatus>("serp_task_status", args),
+
+  serpTaskRecentBatches: (args: { limit: number }) =>
+    invoke<BatchSummary[]>("serp_task_recent_batches", args),
 };
+
+export interface TaskBatchId {
+  batch_id: string;
+  task_count: number;
+  cost_usd: number;
+  estimated_usd: number;
+}
+
+export interface SerpTask {
+  task_id: string;
+  batch_id: string;
+  keyword: string;
+  location_code: number;
+  language_code: string;
+  depth: number;
+  status: string;
+  posted_at: string | null;
+  fetched_at: string | null;
+  poll_attempts: number;
+  cost_usd: number | null;
+  error: string | null;
+}
+
+export interface StoredSerpItem {
+  task_id: string;
+  position: number;
+  kind: string;
+  url: string | null;
+  title: string | null;
+  description: string | null;
+  domain: string | null;
+}
+
+export interface TaskBatchStatus {
+  batch_id: string;
+  tasks: SerpTask[];
+  results: Record<string, StoredSerpItem[]>;
+}
+
+export interface BatchSummary {
+  batch_id: string;
+  total: number;
+  pending: number;
+  ready: number;
+  fetched: number;
+  failed: number;
+  posted_at: string | null;
+}
 
 export interface SerpResultItem {
   kind: string;

--- a/apps/dataforseo-app/src/routes/SerpPage.tsx
+++ b/apps/dataforseo-app/src/routes/SerpPage.tsx
@@ -1,172 +1,47 @@
-import { useMemo, useState } from "react";
-import toast from "react-hot-toast";
+import { useState } from "react";
 
-import CostPreview from "../components/CostPreview";
-import { formatUsd } from "../lib/format";
-import { tauriApi, type SerpLiveBatch, type SerpResultItem } from "../lib/tauri";
+import BulkTab from "./serp/BulkTab";
+import QuickTab from "./serp/QuickTab";
 
-const DEFAULT_LOCATION = 2276;
-const DEFAULT_LANGUAGE = "de";
+const TABS = [
+  { id: "quick", label: "Quick (Live)" },
+  { id: "bulk", label: "Bulk (Standard Queue)" },
+] as const;
 
-const KIND_COLORS: Record<string, string> = {
-  organic: "bg-slate-100 text-slate-700",
-  featured_snippet: "bg-amber-100 text-amber-800",
-  people_also_ask: "bg-sky-100 text-sky-800",
-  paid: "bg-emerald-100 text-emerald-800",
-  ai_overview: "bg-violet-100 text-violet-800",
-};
-
-function safePathname(url: string): string {
-  try {
-    return new URL(url).pathname || url;
-  } catch {
-    return url;
-  }
-}
+type TabId = (typeof TABS)[number]["id"];
 
 export default function SerpPage() {
-  const [keyword, setKeyword] = useState("");
-  const [depth, setDepth] = useState(10);
-  const [busy, setBusy] = useState(false);
-  const [batch, setBatch] = useState<SerpLiveBatch | null>(null);
-
-  const trimmed = keyword.trim();
-
-  const costAction = useMemo(
-    () =>
-      ({
-        kind: "Serp",
-        count: 1,
-        mode: "live",
-        depth,
-        extra_params: 0,
-      }) as const,
-    [depth],
-  );
-
-  async function onRun() {
-    if (!trimmed) return;
-    setBusy(true);
-    try {
-      const result = await tauriApi.serpLive({
-        keyword: trimmed,
-        locationCode: DEFAULT_LOCATION,
-        languageCode: DEFAULT_LANGUAGE,
-        depth,
-      });
-      setBatch(result);
-      toast.success(`${result.items.length} results (${formatUsd(result.cost_usd)})`);
-    } catch (e) {
-      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
-    } finally {
-      setBusy(false);
-    }
-  }
+  const [active, setActive] = useState<TabId>("quick");
 
   return (
     <section className="flex flex-col gap-6">
       <header>
-        <h2 className="text-xl font-semibold">SERP — Quick Check</h2>
+        <h2 className="text-xl font-semibold">SERP</h2>
         <p className="text-sm text-slate-600">
-          Live Google organic results for one keyword. Standard-queue bulk lands in a later milestone.
+          Live single-keyword check or bulk Standard-Queue tasks. Bulk results stream into the Tasks page as the
+          background poller fetches them.
         </p>
       </header>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_320px]">
-        <div className="flex flex-col gap-2">
-          <label htmlFor="serp-kw" className="text-sm font-medium text-slate-700">
-            Keyword
-          </label>
-          <input
-            id="serp-kw"
-            type="text"
-            value={keyword}
-            onChange={(e) => setKeyword(e.target.value)}
-            disabled={busy}
-            className="rounded border px-2 py-1 font-mono text-sm disabled:bg-slate-50"
-            placeholder="seo agentur"
-            spellCheck={false}
-            autoComplete="off"
-          />
-        </div>
-
-        <div className="flex flex-col gap-3">
-          <CostPreview
-            action={costAction}
-            details={[
-              `Depth ${depth} (${depth / 10}x base)`,
-              `Location ${DEFAULT_LOCATION}, Language ${DEFAULT_LANGUAGE}`,
-            ]}
-            disabled={!trimmed || busy}
-          />
-          <label className="flex flex-col gap-1 text-sm">
-            <span className="text-slate-700">Depth: {depth}</span>
-            <input
-              type="range"
-              min={10}
-              max={100}
-              step={10}
-              value={depth}
-              onChange={(e) => setDepth(parseInt(e.target.value, 10))}
-            />
-          </label>
+      <nav className="flex gap-1 border-b">
+        {TABS.map((tab) => (
           <button
+            key={tab.id}
             type="button"
-            onClick={onRun}
-            disabled={busy || !trimmed}
-            className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+            onClick={() => setActive(tab.id)}
+            className={`-mb-px border-b-2 px-3 py-1.5 text-sm transition-colors ${
+              active === tab.id
+                ? "border-slate-800 font-medium text-slate-800"
+                : "border-transparent text-slate-500 hover:text-slate-700"
+            }`}
           >
-            {busy ? "Running…" : "Run"}
+            {tab.label}
           </button>
-        </div>
-      </div>
+        ))}
+      </nav>
 
-      {batch && (
-        <div className="text-xs text-slate-500">
-          {batch.items.length} items for &ldquo;{batch.keyword}&rdquo; · actual cost {formatUsd(batch.cost_usd)} (estimated{" "}
-          {formatUsd(batch.estimated_usd)})
-        </div>
-      )}
-
-      <ol className="flex flex-col gap-3">
-        {batch?.items.map((item, i) => (
-          <SerpRow key={`${item.url ?? i}-${i}`} item={item} />
-        )) ?? null}
-        {batch && batch.items.length === 0 && (
-          <li className="rounded border bg-white p-8 text-center text-sm text-slate-500">
-            No items returned.
-          </li>
-        )}
-        {!batch && (
-          <li className="rounded border bg-white p-8 text-center text-sm text-slate-500">
-            Enter a keyword above and click Run.
-          </li>
-        )}
-      </ol>
+      {active === "quick" && <QuickTab />}
+      {active === "bulk" && <BulkTab />}
     </section>
-  );
-}
-
-function SerpRow({ item }: { item: SerpResultItem }) {
-  const colorClass = KIND_COLORS[item.kind] ?? "bg-slate-100 text-slate-700";
-  return (
-    <li className="rounded border bg-white p-3">
-      <div className="flex items-center gap-2 text-xs text-slate-500">
-        {item.rank_absolute != null && <span className="font-mono">#{item.rank_absolute}</span>}
-        <span className={`rounded px-1.5 py-0.5 ${colorClass}`}>{item.kind}</span>
-        {item.domain && <span className="font-mono">{item.domain}</span>}
-      </div>
-      {item.url && (
-        <a
-          href={item.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mt-1 block text-blue-600 hover:underline"
-        >
-          {item.title ?? safePathname(item.url)}
-        </a>
-      )}
-      {item.description && <p className="mt-1 text-sm text-slate-600">{item.description}</p>}
-    </li>
   );
 }

--- a/apps/dataforseo-app/src/routes/TasksPage.tsx
+++ b/apps/dataforseo-app/src/routes/TasksPage.tsx
@@ -1,11 +1,154 @@
+import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+
+import { tauriApi, type BatchSummary, type TaskBatchStatus } from "../lib/tauri";
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: "bg-amber-100 text-amber-800",
+  ready: "bg-sky-100 text-sky-800",
+  fetched: "bg-emerald-100 text-emerald-800",
+  failed: "bg-rose-100 text-rose-800",
+};
+
 export default function TasksPage() {
+  const [batches, setBatches] = useState<BatchSummary[] | null>(null);
+  const [selected, setSelected] = useState<TaskBatchStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function refreshBatches() {
+    setBusy(true);
+    try {
+      const list = await tauriApi.serpTaskRecentBatches({ limit: 50 });
+      setBatches(list);
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function selectBatch(batchId: string) {
+    setBusy(true);
+    try {
+      const status = await tauriApi.serpTaskStatus({ batchId });
+      setSelected(status);
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  useEffect(() => {
+    refreshBatches();
+    // The Rust poller ticks every 30s, so a 30s UI refresh is sufficient
+    // to surface progress without piling up duplicate work.
+    const id = setInterval(refreshBatches, 30_000);
+    return () => clearInterval(id);
+  }, []);
+
   return (
-    <section>
-      <h2 className="text-xl font-semibold">Tasks</h2>
-      <p className="mt-2 text-sm text-slate-600">
-        Standard-Queue-Tasks (pending, ready, fetched, failed). Polling-Worker
-        läuft im Rust-Backend.
-      </p>
+    <section className="flex flex-col gap-6">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Tasks</h2>
+          <p className="text-sm text-slate-600">
+            Standard-Queue SERP batches. Auto-refreshes every 30s.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={refreshBatches}
+          disabled={busy}
+          className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+        >
+          Refresh
+        </button>
+      </header>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-[300px_1fr]">
+        <div className="flex flex-col gap-1">
+          {batches?.length === 0 && (
+            <div className="rounded border bg-white p-4 text-sm text-slate-500">
+              No batches yet. Submit one from /serp → Bulk.
+            </div>
+          )}
+          {batches?.map((b) => (
+            <button
+              key={b.batch_id}
+              type="button"
+              onClick={() => selectBatch(b.batch_id)}
+              className={`rounded border bg-white px-3 py-2 text-left text-sm hover:bg-slate-50 ${
+                selected?.batch_id === b.batch_id ? "border-slate-800" : ""
+              }`}
+            >
+              <div className="font-mono text-xs">{b.batch_id}</div>
+              <div className="mt-1 flex flex-wrap gap-1 text-xs">
+                {b.pending > 0 && <Pill kind="pending" count={b.pending} />}
+                {b.ready > 0 && <Pill kind="ready" count={b.ready} />}
+                {b.fetched > 0 && <Pill kind="fetched" count={b.fetched} />}
+                {b.failed > 0 && <Pill kind="failed" count={b.failed} />}
+                <span className="text-slate-500">/ {b.total}</span>
+              </div>
+            </button>
+          ))}
+        </div>
+
+        <div>
+          {!selected && (
+            <div className="rounded border bg-white p-8 text-center text-sm text-slate-500">
+              Select a batch to inspect tasks and results.
+            </div>
+          )}
+          {selected && (
+            <div className="flex flex-col gap-3">
+              {selected.tasks.map((t) => (
+                <div key={t.task_id} className="rounded border bg-white p-3">
+                  <div className="flex items-center gap-2 text-xs">
+                    <Pill kind={t.status} />
+                    <span className="font-mono">{t.keyword}</span>
+                    <span className="ml-auto text-slate-500">
+                      depth {t.depth}, attempts {t.poll_attempts}
+                    </span>
+                  </div>
+                  {selected.results[t.task_id] && (
+                    <ol className="mt-2 list-decimal pl-5 text-sm">
+                      {selected.results[t.task_id].slice(0, 5).map((item) => (
+                        <li key={item.position}>
+                          <span className="font-mono text-xs text-slate-500">
+                            #{item.position}
+                          </span>{" "}
+                          {item.title ?? item.url ?? item.kind}{" "}
+                          {item.domain && (
+                            <span className="text-xs text-slate-500">({item.domain})</span>
+                          )}
+                        </li>
+                      ))}
+                      {selected.results[t.task_id].length > 5 && (
+                        <li className="text-xs text-slate-500">
+                          +{selected.results[t.task_id].length - 5} more
+                        </li>
+                      )}
+                    </ol>
+                  )}
+                  {t.error && (
+                    <div className="mt-2 text-xs text-rose-700">{t.error}</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
     </section>
+  );
+}
+
+function Pill({ kind, count }: { kind: string; count?: number }) {
+  const className = STATUS_COLORS[kind] ?? "bg-slate-100 text-slate-700";
+  return (
+    <span className={`rounded px-1.5 py-0.5 ${className}`}>
+      {count != null ? `${count} ${kind}` : kind}
+    </span>
   );
 }

--- a/apps/dataforseo-app/src/routes/serp/BulkTab.tsx
+++ b/apps/dataforseo-app/src/routes/serp/BulkTab.tsx
@@ -1,0 +1,116 @@
+import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import { Link } from "react-router-dom";
+
+import BulkKeywordInput, { parseKeywords } from "../../components/BulkKeywordInput";
+import CostPreview from "../../components/CostPreview";
+import { formatUsd } from "../../lib/format";
+import { tauriApi } from "../../lib/tauri";
+
+const DEFAULT_LOCATION = 2276;
+const DEFAULT_LANGUAGE = "de";
+const MAX_KEYWORDS = 100;
+
+export default function BulkTab() {
+  const [raw, setRaw] = useState("");
+  const [depth, setDepth] = useState(10);
+  const [busy, setBusy] = useState(false);
+  const [lastBatchId, setLastBatchId] = useState<string | null>(null);
+
+  const keywords = useMemo(() => parseKeywords(raw), [raw]);
+
+  const costAction = useMemo(
+    () =>
+      ({
+        kind: "Serp",
+        count: keywords.length,
+        mode: "standard",
+        depth,
+        extra_params: 0,
+      }) as const,
+    [keywords.length, depth],
+  );
+
+  async function onRun() {
+    if (keywords.length === 0 || keywords.length > MAX_KEYWORDS) return;
+    setBusy(true);
+    try {
+      const result = await tauriApi.serpTaskCreate({
+        keywords,
+        locationCode: DEFAULT_LOCATION,
+        languageCode: DEFAULT_LANGUAGE,
+        depth,
+      });
+      setLastBatchId(result.batch_id);
+      toast.success(
+        `Submitted ${result.task_count} tasks (${formatUsd(result.cost_usd)}). Polling will fetch results in the background.`,
+      );
+      setRaw("");
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="rounded border bg-blue-50 p-3 text-sm text-blue-900">
+        Bulk SERP runs through the Standard Queue (~3.3x cheaper than Live, 1–5 min wait per task). Submit up
+        to {MAX_KEYWORDS} keywords; a background poller picks up the results. Track progress on the{" "}
+        <Link to="/tasks" className="underline">
+          Tasks
+        </Link>{" "}
+        page.
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_320px]">
+        <BulkKeywordInput
+          value={raw}
+          onChange={setRaw}
+          disabled={busy}
+          maxKeywords={MAX_KEYWORDS}
+        />
+        <div className="flex flex-col gap-3">
+          <CostPreview
+            action={costAction}
+            details={[
+              `${keywords.length} keywords`,
+              `Depth ${depth}, Standard Queue`,
+              `Location ${DEFAULT_LOCATION}, Language ${DEFAULT_LANGUAGE}`,
+            ]}
+            disabled={keywords.length === 0 || busy}
+          />
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-slate-700">Depth: {depth}</span>
+            <input
+              type="range"
+              min={10}
+              max={100}
+              step={10}
+              value={depth}
+              onChange={(e) => setDepth(parseInt(e.target.value, 10))}
+            />
+          </label>
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={busy || keywords.length === 0 || keywords.length > MAX_KEYWORDS}
+            className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+          >
+            {busy ? "Submitting…" : "Submit batch"}
+          </button>
+        </div>
+      </div>
+
+      {lastBatchId && (
+        <div className="rounded border bg-slate-50 p-3 text-sm">
+          Batch <span className="font-mono">{lastBatchId}</span> submitted.{" "}
+          <Link to="/tasks" className="text-blue-600 underline">
+            View on Tasks page
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/dataforseo-app/src/routes/serp/QuickTab.tsx
+++ b/apps/dataforseo-app/src/routes/serp/QuickTab.tsx
@@ -1,0 +1,165 @@
+import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+
+import CostPreview from "../../components/CostPreview";
+import { formatUsd } from "../../lib/format";
+import { tauriApi, type SerpLiveBatch, type SerpResultItem } from "../../lib/tauri";
+
+const DEFAULT_LOCATION = 2276;
+const DEFAULT_LANGUAGE = "de";
+
+const KIND_COLORS: Record<string, string> = {
+  organic: "bg-slate-100 text-slate-700",
+  featured_snippet: "bg-amber-100 text-amber-800",
+  people_also_ask: "bg-sky-100 text-sky-800",
+  paid: "bg-emerald-100 text-emerald-800",
+  ai_overview: "bg-violet-100 text-violet-800",
+};
+
+function safePathname(url: string): string {
+  try {
+    return new URL(url).pathname || url;
+  } catch {
+    return url;
+  }
+}
+
+export default function QuickTab() {
+  const [keyword, setKeyword] = useState("");
+  const [depth, setDepth] = useState(10);
+  const [busy, setBusy] = useState(false);
+  const [batch, setBatch] = useState<SerpLiveBatch | null>(null);
+
+  const trimmed = keyword.trim();
+
+  const costAction = useMemo(
+    () =>
+      ({
+        kind: "Serp",
+        count: 1,
+        mode: "live",
+        depth,
+        extra_params: 0,
+      }) as const,
+    [depth],
+  );
+
+  async function onRun() {
+    if (!trimmed) return;
+    setBusy(true);
+    try {
+      const result = await tauriApi.serpLive({
+        keyword: trimmed,
+        locationCode: DEFAULT_LOCATION,
+        languageCode: DEFAULT_LANGUAGE,
+        depth,
+      });
+      setBatch(result);
+      toast.success(`${result.items.length} results (${formatUsd(result.cost_usd)})`);
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_320px]">
+        <div className="flex flex-col gap-2">
+          <label htmlFor="serp-kw" className="text-sm font-medium text-slate-700">
+            Keyword
+          </label>
+          <input
+            id="serp-kw"
+            type="text"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            disabled={busy}
+            className="rounded border px-2 py-1 font-mono text-sm disabled:bg-slate-50"
+            placeholder="seo agentur"
+            spellCheck={false}
+            autoComplete="off"
+          />
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <CostPreview
+            action={costAction}
+            details={[
+              `Depth ${depth} (${depth / 10}x base)`,
+              `Location ${DEFAULT_LOCATION}, Language ${DEFAULT_LANGUAGE}`,
+            ]}
+            disabled={!trimmed || busy}
+          />
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="text-slate-700">Depth: {depth}</span>
+            <input
+              type="range"
+              min={10}
+              max={100}
+              step={10}
+              value={depth}
+              onChange={(e) => setDepth(parseInt(e.target.value, 10))}
+            />
+          </label>
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={busy || !trimmed}
+            className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+          >
+            {busy ? "Running…" : "Run"}
+          </button>
+        </div>
+      </div>
+
+      {batch && (
+        <div className="text-xs text-slate-500">
+          {batch.items.length} items for &ldquo;{batch.keyword}&rdquo; · actual cost {formatUsd(batch.cost_usd)} (estimated{" "}
+          {formatUsd(batch.estimated_usd)})
+        </div>
+      )}
+
+      <ol className="flex flex-col gap-3">
+        {batch?.items.map((item, i) => (
+          <SerpRow key={`${item.url ?? i}-${i}`} item={item} />
+        )) ?? null}
+        {batch && batch.items.length === 0 && (
+          <li className="rounded border bg-white p-8 text-center text-sm text-slate-500">
+            No items returned.
+          </li>
+        )}
+        {!batch && (
+          <li className="rounded border bg-white p-8 text-center text-sm text-slate-500">
+            Enter a keyword above and click Run.
+          </li>
+        )}
+      </ol>
+    </div>
+  );
+}
+
+function SerpRow({ item }: { item: SerpResultItem }) {
+  const colorClass = KIND_COLORS[item.kind] ?? "bg-slate-100 text-slate-700";
+  return (
+    <li className="rounded border bg-white p-3">
+      <div className="flex items-center gap-2 text-xs text-slate-500">
+        {item.rank_absolute != null && <span className="font-mono">#{item.rank_absolute}</span>}
+        <span className={`rounded px-1.5 py-0.5 ${colorClass}`}>{item.kind}</span>
+        {item.domain && <span className="font-mono">{item.domain}</span>}
+      </div>
+      {item.url && (
+        <a
+          href={item.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-1 block text-blue-600 hover:underline"
+        >
+          {item.title ?? safePathname(item.url)}
+        </a>
+      )}
+      {item.description && <p className="mt-1 text-sm text-slate-600">{item.description}</p>}
+    </li>
+  );
+}


### PR DESCRIPTION
## Summary

Implements the Tier 1 Standard-Queue SERP task pipeline — the only async/polling pattern in Tier 1 and the architectural template for On-Page in Tier 3. Stacked on PR #21.

## What works after this PR

1. /serp now has two tabs: Quick (existing Live one-shot) and Bulk (new).
2. Bulk: paste up to 100 keywords, pick depth, submit. Backend posts the batch via task_post (Standard Queue, ~3.3x cheaper than Live), returns a batch_id.
3. A background tokio task ticks every 30s: queries pending tasks, asks /tasks_ready, marks matches, fetches each ready task's results, persists them.
4. /tasks shows recent batches with live counts (pending / ready / fetched / failed). Click a batch to inspect each task and the top-5 SERP rows.

## Backend changes (src-tauri/)

API client:
- api::client::get_json: shared GET helper alongside post_json.
- api::serp gains task_post, tasks_ready, task_get_regular. Each checks the DataForSEO internal status_code (20000) and surfaces parse failures as AppError::Parse.

Persistence:
- store::serp_tasks: insert_pending, mark_ready, mark_fetched, record_attempt (FAIL_AFTER_ATTEMPTS = 48 polls = 24h ceiling at 30s interval), find_pending, find_ready, list_batch, list_recent_batches.
- store::serp_results: insert_batch (transactional, ON CONFLICT upsert), list_for_task.

Background worker:
- tasks::poller: tokio loop, 30s interval. DB access wrapped in spawn_blocking since the duckdb Connection is sync.
- lib.rs setup() spawns the poller via tauri::async_runtime::spawn after AppState is constructed.

Commands:
- commands::serp::serp_task_create: validates 1..=100 keywords, calls task_post, inserts serp_tasks rows + a ledger entry, returns the batch_id.
- commands::serp::serp_task_status: returns SerpTask rows + a results map for a batch.
- commands::serp::serp_task_recent_batches: aggregated counts per batch for the Tasks sidebar.

## Frontend changes (src/)

- routes/SerpPage refactored as a Quick / Bulk tabbed shell.
- routes/serp/QuickTab: extracted from the previous SerpPage with no behavioral change.
- routes/serp/BulkTab: BulkKeywordInput (max 100), Standard-Queue cost preview, depth slider, submit-batch button.
- routes/TasksPage: real implementation. Auto-refreshes batch list every 30s; click a batch to inspect.
- lib/tauri.ts: serpTaskCreate / serpTaskStatus / serpTaskRecentBatches wrappers + types.

## Out of scope, deferred

- Tauri events for live per-task progress (current refresh is poll-based 30s on the page; events would be smoother).
- Recording failed API calls in the ledger across all six commands (carried over from PR #21 follow-up).
- The advanced SERP variant (~5x cost, richer items).
- Cancellation/shutdown semantics for the poller (currently relies on the runtime tearing down on close).

## Test plan
- [ ] cd apps/dataforseo-app/src-tauri && cargo check.
- [ ] npm run tauri:dev with valid credentials. Submit a 5-keyword batch from /serp → Bulk. Watch /tasks: counts should move from 5 pending → ready → fetched within 1-5 minutes.
- [ ] Inspect ~/.local/share/com.bluebranch.dataforseo-app/dataforseo-app.duckdb after a complete run: serp_tasks all status='fetched', serp_results populated, api_calls has both task_post (cost) and task_get rows.
- [ ] Kill the app while a batch is mid-flight, restart, confirm the poller picks up where it left off.


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_