### PR TITLE
REFACTOR: Unify command skeleton, record failures, parallelise poller

### DIFF
--- a/apps/dataforseo-app/src-tauri/Cargo.toml
+++ b/apps/dataforseo-app/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1"
 thiserror = "2"
 
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
+futures = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 tracing = "0.1"

--- a/apps/dataforseo-app/src-tauri/src/commands/keywords.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/keywords.rs
@@ -8,12 +8,13 @@ use ts_rs::TS;
 
 use crate::api::keywords_data::SearchVolumeRequest;
 use crate::api::labs::{LabsKeywordItem, RankedKeywordItem};
+use crate::commands::ledger::run_with_ledger;
 use crate::domain::cost::{self, CostAction};
+use crate::domain::endpoints;
 use crate::domain::types::Mode;
-use crate::errors::Result;
+use crate::errors::{AppError, Result};
 use crate::state::AppState;
 use crate::store::keywords_cache::{self, KeywordVolume};
-use crate::store::ledger::{self, LedgerEntry};
 
 #[derive(Debug, Serialize, TS)]
 #[ts(export, export_to = "../src/lib/types/")]
@@ -50,7 +51,6 @@ pub async fn keywords_search_volume(
         mode: Mode::Live,
     });
 
-    // Cache lookup (blocking IO -> spawn_blocking).
     let store = state.store.clone();
     let cache_keywords = cleaned.clone();
     let lang_for_cache = language_code.clone();
@@ -67,7 +67,7 @@ pub async fn keywords_search_volume(
             })
         })
         .await
-        .map_err(|e| crate::errors::AppError::Internal(e.to_string()))??
+        .map_err(|e| AppError::Internal(e.to_string()))??
     } else {
         Default::default()
     };
@@ -82,14 +82,28 @@ pub async fn keywords_search_volume(
     let mut api_cost = 0.0;
 
     if !misses.is_empty() {
-        let resp = state
-            .api
-            .google_ads_search_volume_live(SearchVolumeRequest {
-                keywords: &misses,
-                location_code,
-                language_code: &language_code,
-            })
-            .await?;
+        let api = state.api.clone();
+        let misses_for_call = misses.clone();
+        let lang_for_call = language_code.clone();
+        let resp = run_with_ledger(
+            state.store.clone(),
+            endpoints::KEYWORDS_SEARCH_VOLUME,
+            Mode::Live,
+            estimated_usd,
+            misses.len() as i64,
+            move || async move {
+                let r = api
+                    .google_ads_search_volume_live(SearchVolumeRequest {
+                        keywords: &misses_for_call,
+                        location_code,
+                        language_code: &lang_for_call,
+                    })
+                    .await?;
+                let cost = r.cost;
+                Ok((r, cost))
+            },
+        )
+        .await?;
 
         api_cost = resp.cost;
 
@@ -109,32 +123,16 @@ pub async fn keywords_search_volume(
             })
             .collect();
 
-        // Persist fresh rows + ledger entry.
         let store = state.store.clone();
         let lang_for_write = language_code.clone();
         let to_persist = fresh_rows.clone();
-        let request_size = misses.len() as i64;
         task::spawn_blocking(move || -> Result<()> {
             store.with_conn(|c| {
-                keywords_cache::put_batch(c, location_code, &lang_for_write, &to_persist)?;
-                ledger::record(
-                    c,
-                    &LedgerEntry {
-                        endpoint: "google_ads.search_volume",
-                        mode: "live",
-                        cost_usd: api_cost,
-                        estimated_usd: Some(estimated_usd),
-                        request_size: Some(request_size),
-                        response_status: Some(20000),
-                        duration_ms: None,
-                        task_id: None,
-                        error: None,
-                    },
-                )
+                keywords_cache::put_batch(c, location_code, &lang_for_write, &to_persist)
             })
         })
         .await
-        .map_err(|e| crate::errors::AppError::Internal(e.to_string()))??;
+        .map_err(|e| AppError::Internal(e.to_string()))??;
     }
 
     let mut items: Vec<KeywordVolume> = cached.into_values().collect();
@@ -198,14 +196,22 @@ pub async fn keywords_suggestions(
     limit: u32,
 ) -> Result<LabsBatch> {
     let estimated_usd = cost::estimate(&CostAction::KeywordsSuggestions { mode: Mode::Live });
-
-    let resp = state
-        .api
-        .labs_keyword_suggestions(&seed, location_code, &language_code, limit)
-        .await?;
-
-    record_labs_call(state.clone(), "labs.keyword_suggestions", &resp, estimated_usd).await?;
-
+    let api = state.api.clone();
+    let resp = run_with_ledger(
+        state.store.clone(),
+        endpoints::LABS_KEYWORD_SUGGESTIONS,
+        Mode::Live,
+        estimated_usd,
+        1,
+        move || async move {
+            let r = api
+                .labs_keyword_suggestions(&seed, location_code, &language_code, limit)
+                .await?;
+            let cost = r.cost;
+            Ok((r, cost))
+        },
+    )
+    .await?;
     Ok(LabsBatch {
         items: resp.items.into_iter().map(LabsKeyword::from).collect(),
         cost_usd: resp.cost,
@@ -223,14 +229,22 @@ pub async fn keywords_related(
     depth: u32,
 ) -> Result<LabsBatch> {
     let estimated_usd = cost::estimate(&CostAction::KeywordsRelated { depth, mode: Mode::Live });
-
-    let resp = state
-        .api
-        .labs_related_keywords(&seed, location_code, &language_code, depth)
-        .await?;
-
-    record_labs_call(state.clone(), "labs.related_keywords", &resp, estimated_usd).await?;
-
+    let api = state.api.clone();
+    let resp = run_with_ledger(
+        state.store.clone(),
+        endpoints::LABS_RELATED_KEYWORDS,
+        Mode::Live,
+        estimated_usd,
+        1,
+        move || async move {
+            let r = api
+                .labs_related_keywords(&seed, location_code, &language_code, depth)
+                .await?;
+            let cost = r.cost;
+            Ok((r, cost))
+        },
+    )
+    .await?;
     Ok(LabsBatch {
         items: resp.items.into_iter().map(LabsKeyword::from).collect(),
         cost_usd: resp.cost,
@@ -248,21 +262,22 @@ pub async fn keywords_for_domain(
     limit: u32,
 ) -> Result<LabsBatch> {
     let estimated_usd = cost::estimate(&CostAction::KeywordsForDomain { mode: Mode::Live });
-
-    let resp = state
-        .api
-        .labs_keywords_for_site(&target, location_code, &language_code, limit)
-        .await?;
-
-    record_ledger_entry(
-        state.clone(),
-        "labs.keywords_for_site",
-        resp.cost,
+    let api = state.api.clone();
+    let resp = run_with_ledger(
+        state.store.clone(),
+        endpoints::LABS_KEYWORDS_FOR_SITE,
+        Mode::Live,
         estimated_usd,
-        resp.items.len() as i64,
+        1,
+        move || async move {
+            let r = api
+                .labs_keywords_for_site(&target, location_code, &language_code, limit)
+                .await?;
+            let cost = r.cost;
+            Ok((r, cost))
+        },
     )
     .await?;
-
     Ok(LabsBatch {
         items: resp.items.into_iter().map(LabsKeyword::from).collect(),
         cost_usd: resp.cost,
@@ -316,64 +331,25 @@ pub async fn keywords_ranked(
     limit: u32,
 ) -> Result<RankedBatch> {
     let estimated_usd = cost::estimate(&CostAction::KeywordsForDomain { mode: Mode::Live });
-
-    let resp = state
-        .api
-        .labs_ranked_keywords(&target, location_code, &language_code, limit)
-        .await?;
-
-    record_ledger_entry(
-        state.clone(),
-        "labs.ranked_keywords",
-        resp.cost,
+    let api = state.api.clone();
+    let resp = run_with_ledger(
+        state.store.clone(),
+        endpoints::LABS_RANKED_KEYWORDS,
+        Mode::Live,
         estimated_usd,
-        resp.items.len() as i64,
+        1,
+        move || async move {
+            let r = api
+                .labs_ranked_keywords(&target, location_code, &language_code, limit)
+                .await?;
+            let cost = r.cost;
+            Ok((r, cost))
+        },
     )
     .await?;
-
     Ok(RankedBatch {
         items: resp.items.into_iter().map(RankedKeyword::from).collect(),
         cost_usd: resp.cost,
         estimated_usd,
     })
-}
-
-async fn record_labs_call(
-    state: State<'_, AppState>,
-    endpoint: &'static str,
-    resp: &crate::api::labs::LabsResponse,
-    estimated_usd: f64,
-) -> Result<()> {
-    record_ledger_entry(state, endpoint, resp.cost, estimated_usd, resp.items.len() as i64).await
-}
-
-async fn record_ledger_entry(
-    state: State<'_, AppState>,
-    endpoint: &'static str,
-    cost_usd: f64,
-    estimated_usd: f64,
-    items_len: i64,
-) -> Result<()> {
-    let store = state.store.clone();
-    task::spawn_blocking(move || -> Result<()> {
-        store.with_conn(|c| {
-            ledger::record(
-                c,
-                &LedgerEntry {
-                    endpoint,
-                    mode: "live",
-                    cost_usd,
-                    estimated_usd: Some(estimated_usd),
-                    request_size: Some(items_len),
-                    response_status: Some(20000),
-                    duration_ms: None,
-                    task_id: None,
-                    error: None,
-                },
-            )
-        })
-    })
-    .await
-    .map_err(|e| crate::errors::AppError::Internal(e.to_string()))??;
-    Ok(())
 }

--- a/apps/dataforseo-app/src-tauri/src/commands/ledger.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/ledger.rs
@@ -1,14 +1,100 @@
+use std::sync::Arc;
+
 use tauri::State;
 use tokio::task;
 
 use crate::domain::cost::{self, CostAction};
+use crate::domain::types::Mode;
 use crate::errors::{AppError, Result};
 use crate::state::AppState;
-use crate::store::ledger::{self, CallLogRow, UsageSummary};
+use crate::store::ledger::{self, CallLogRow, LedgerEntry, UsageSummary};
+use crate::store::Store;
 
 #[tauri::command]
 pub fn estimate_cost(action: CostAction) -> Result<f64> {
     Ok(cost::estimate(&action))
+}
+
+/// Run an API call, time it, and append a ledger row whether the call
+/// succeeds or fails. The closure returns (response, cost_usd) on success;
+/// the caller has the only place that knows where to pull `cost` from on
+/// the typed response.
+///
+/// Concentrating this skeleton in one place is what gives us:
+/// - duration_ms measurement on every command,
+/// - failure rows with the upstream API status_code (when present), so the
+///   Usage page surfaces the user's failed calls,
+/// - a single audit trail for the "did we tell DataForSEO about this?"
+///   question.
+pub async fn run_with_ledger<T, F, Fut>(
+    store: Arc<Store>,
+    endpoint: &'static str,
+    mode: Mode,
+    estimated_usd: f64,
+    request_size: i64,
+    op: F,
+) -> Result<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<(T, f64)>>,
+{
+    let start = std::time::Instant::now();
+    let result = op().await;
+    let duration_ms = start.elapsed().as_millis() as i64;
+
+    let mode_str = mode;
+    match result {
+        Ok((value, cost_usd)) => {
+            let store_clone = store.clone();
+            task::spawn_blocking(move || -> Result<()> {
+                store_clone.with_conn(|c| {
+                    ledger::record(
+                        c,
+                        &LedgerEntry {
+                            endpoint,
+                            mode: mode_str,
+                            cost_usd,
+                            estimated_usd: Some(estimated_usd),
+                            request_size: Some(request_size),
+                            response_status: Some(20000),
+                            duration_ms: Some(duration_ms),
+                            task_id: None,
+                            error: None,
+                        },
+                    )
+                })
+            })
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))??;
+            Ok(value)
+        }
+        Err(e) => {
+            let status = e.api_status_code();
+            let msg = e.to_string();
+            let store_clone = store.clone();
+            task::spawn_blocking(move || -> Result<()> {
+                store_clone.with_conn(|c| {
+                    ledger::record(
+                        c,
+                        &LedgerEntry {
+                            endpoint,
+                            mode: mode_str,
+                            cost_usd: 0.0,
+                            estimated_usd: Some(estimated_usd),
+                            request_size: Some(request_size),
+                            response_status: status,
+                            duration_ms: Some(duration_ms),
+                            task_id: None,
+                            error: Some(&msg),
+                        },
+                    )
+                })
+            })
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))??;
+            Err(e)
+        }
+    }
 }
 
 #[tauri::command]

--- a/apps/dataforseo-app/src-tauri/src/commands/serp.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/serp.rs
@@ -4,11 +4,12 @@ use tokio::task;
 use ts_rs::TS;
 
 use crate::api::serp::SerpItem;
+use crate::commands::ledger::run_with_ledger;
 use crate::domain::cost::{self, CostAction};
+use crate::domain::endpoints;
 use crate::domain::types::Mode;
-use crate::errors::Result;
+use crate::errors::{AppError, Result};
 use crate::state::AppState;
-use crate::store::ledger::{self, LedgerEntry};
 
 #[derive(Debug, Serialize, TS)]
 #[ts(export, export_to = "../src/lib/types/")]
@@ -59,36 +60,22 @@ pub async fn serp_live(
         extra_params: 0,
     });
 
-    let start = std::time::Instant::now();
-    let resp = state
-        .api
-        .serp_google_organic_live(&keyword, location_code, &language_code, depth)
-        .await?;
-    let duration_ms = start.elapsed().as_millis() as i64;
-
-    let store = state.store.clone();
-    let cost = resp.cost;
-    task::spawn_blocking(move || -> Result<()> {
-        store.with_conn(|c| {
-            ledger::record(
-                c,
-                &LedgerEntry {
-                    endpoint: "serp.google.organic.live",
-                    mode: "live",
-                    cost_usd: cost,
-                    estimated_usd: Some(estimated_usd),
-                    // request_size is keyword count, not response item count.
-                    request_size: Some(1),
-                    response_status: Some(20000),
-                    duration_ms: Some(duration_ms),
-                    task_id: None,
-                    error: None,
-                },
-            )
-        })
-    })
-    .await
-    .map_err(|e| crate::errors::AppError::Internal(e.to_string()))??;
+    let api = state.api.clone();
+    let resp = run_with_ledger(
+        state.store.clone(),
+        endpoints::SERP_GOOGLE_ORGANIC_LIVE,
+        Mode::Live,
+        estimated_usd,
+        1,
+        move || async move {
+            let r = api
+                .serp_google_organic_live(&keyword, location_code, &language_code, depth)
+                .await?;
+            let cost = r.cost;
+            Ok((r, cost))
+        },
+    )
+    .await?;
 
     Ok(SerpLiveBatch {
         keyword: resp.keyword,
@@ -131,12 +118,10 @@ pub async fn serp_task_create(
         .collect();
 
     if cleaned.is_empty() {
-        return Err(crate::errors::AppError::Validation(
-            "at least one keyword required".into(),
-        ));
+        return Err(AppError::Validation("at least one keyword required".into()));
     }
     if cleaned.len() > 100 {
-        return Err(crate::errors::AppError::Validation(
+        return Err(AppError::Validation(
             "task_create accepts at most 100 keywords per batch".into(),
         ));
     }
@@ -202,8 +187,8 @@ pub async fn serp_task_create(
                      response_status, duration_ms, task_id, error)
                  VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
                 duckdb::params![
-                    "serp.google.organic.task_post",
-                    "standard",
+                    endpoints::SERP_GOOGLE_ORGANIC_TASK_POST,
+                    Mode::Standard.as_str(),
                     api_cost,
                     Some(estimated_usd),
                     Some(request_size),
@@ -218,7 +203,7 @@ pub async fn serp_task_create(
         })
     })
     .await
-    .map_err(|e| crate::errors::AppError::Internal(e.to_string()))??;
+    .map_err(|e| AppError::Internal(e.to_string()))??;
 
     Ok(TaskBatchId {
         batch_id,
@@ -251,7 +236,7 @@ pub async fn serp_task_status(
         })
     })
     .await
-    .map_err(|e| crate::errors::AppError::Internal(e.to_string()))??;
+    .map_err(|e| AppError::Internal(e.to_string()))??;
 
     Ok(TaskBatchStatus { batch_id, tasks, results })
 }
@@ -267,5 +252,5 @@ pub async fn serp_task_recent_batches(
         store.with_conn(|c| crate::store::serp_tasks::list_recent_batches(c, limit))
     })
     .await
-    .map_err(|e| crate::errors::AppError::Internal(e.to_string()))?
+    .map_err(|e| AppError::Internal(e.to_string()))?
 }

--- a/apps/dataforseo-app/src-tauri/src/domain/endpoints.rs
+++ b/apps/dataforseo-app/src-tauri/src/domain/endpoints.rs
@@ -1,0 +1,12 @@
+//! Endpoint identifiers as constants. Used as the `endpoint` column value
+//! in `api_calls` (the cost ledger). Centralizing them avoids the
+//! string-typo class of bugs when the Usage page groups by endpoint.
+
+pub const KEYWORDS_SEARCH_VOLUME: &str = "google_ads.search_volume";
+pub const LABS_KEYWORD_SUGGESTIONS: &str = "labs.keyword_suggestions";
+pub const LABS_RELATED_KEYWORDS: &str = "labs.related_keywords";
+pub const LABS_KEYWORDS_FOR_SITE: &str = "labs.keywords_for_site";
+pub const LABS_RANKED_KEYWORDS: &str = "labs.ranked_keywords";
+pub const SERP_GOOGLE_ORGANIC_LIVE: &str = "serp.google.organic.live";
+pub const SERP_GOOGLE_ORGANIC_TASK_POST: &str = "serp.google.organic.task_post";
+pub const SERP_GOOGLE_ORGANIC_TASK_GET: &str = "serp.google.organic.task_get";

--- a/apps/dataforseo-app/src-tauri/src/domain/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/domain/mod.rs
@@ -1,2 +1,3 @@
 pub mod cost;
+pub mod endpoints;
 pub mod types;

--- a/apps/dataforseo-app/src-tauri/src/domain/types.rs
+++ b/apps/dataforseo-app/src-tauri/src/domain/types.rs
@@ -10,6 +10,16 @@ pub enum Mode {
     Standard,
 }
 
+impl Mode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Mode::Live => "live",
+            Mode::Priority => "priority",
+            Mode::Standard => "standard",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "../src/lib/types/")]
 pub enum EndpointFamily {

--- a/apps/dataforseo-app/src-tauri/src/errors.rs
+++ b/apps/dataforseo-app/src-tauri/src/errors.rs
@@ -34,6 +34,18 @@ pub enum AppError {
     Internal(String),
 }
 
+impl AppError {
+    /// Return the upstream API status code if this error originated as an
+    /// explicit DataForSEO error, else None. Used by the ledger to surface
+    /// failures alongside successful calls.
+    pub fn api_status_code(&self) -> Option<i64> {
+        match self {
+            AppError::Api { status_code, .. } => Some(*status_code as i64),
+            _ => None,
+        }
+    }
+}
+
 impl From<reqwest::Error> for AppError {
     fn from(e: reqwest::Error) -> Self {
         AppError::Network(e.to_string())

--- a/apps/dataforseo-app/src-tauri/src/store/ledger.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/ledger.rs
@@ -2,13 +2,14 @@ use duckdb::{params, Connection};
 use serde::Serialize;
 use ts_rs::TS;
 
+use crate::domain::types::Mode;
 use crate::errors::Result;
 
 #[derive(Debug, Clone, Serialize, TS)]
 #[ts(export, export_to = "../src/lib/types/")]
 pub struct LedgerEntry<'a> {
     pub endpoint: &'a str,
-    pub mode: &'a str,
+    pub mode: Mode,
     pub cost_usd: f64,
     pub estimated_usd: Option<f64>,
     pub request_size: Option<i64>,
@@ -26,7 +27,7 @@ pub fn record(conn: &mut Connection, entry: &LedgerEntry) -> Result<()> {
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
         params![
             entry.endpoint,
-            entry.mode,
+            entry.mode.as_str(),
             entry.cost_usd,
             entry.estimated_usd,
             entry.request_size,

--- a/apps/dataforseo-app/src-tauri/src/tasks/poller.rs
+++ b/apps/dataforseo-app/src-tauri/src/tasks/poller.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use futures::stream::{self, StreamExt};
 use tokio::task;
 use tokio::time;
 
@@ -13,6 +14,10 @@ use crate::errors::{AppError, Result};
 use crate::store::{serp_results, serp_tasks, Store};
 
 const POLL_INTERVAL_SECS: u64 = 30;
+/// How many task_get calls run concurrently. The SerpTask rate-limiter
+/// (2000 rpm sustained) caps absolute throughput; a small concurrency
+/// keeps the poller responsive without flooding the runtime.
+const TASK_GET_CONCURRENCY: usize = 8;
 
 pub async fn run(api: Arc<ApiClient>, store: Arc<Store>) {
     tracing::info!("serp task poller started (interval {}s)", POLL_INTERVAL_SECS);
@@ -46,26 +51,42 @@ async fn poll_once(api: &Arc<ApiClient>, store: &Arc<Store>) -> Result<()> {
     }
 
     let ready = blocking(store, |c| serp_tasks::find_ready(c)).await?;
-    for task in ready {
-        match api.serp_google_organic_task_get_regular(&task.task_id).await {
+    if ready.is_empty() {
+        return Ok(());
+    }
+
+    // Fetch results concurrently. Each future yields (task_id, Result<resp>);
+    // the rate-limiter inside ApiClient still serialises actual HTTP requests
+    // up to the configured per-family rate, so this is bounded throughput
+    // with parallelised waiting.
+    let fetches = stream::iter(ready.into_iter().map(|t| {
+        let api = api.clone();
+        async move {
+            let r = api.serp_google_organic_task_get_regular(&t.task_id).await;
+            (t.task_id, r)
+        }
+    }))
+    .buffer_unordered(TASK_GET_CONCURRENCY)
+    .collect::<Vec<_>>()
+    .await;
+
+    for (task_id, result) in fetches {
+        match result {
             Ok(resp) => {
-                let task_id = task.task_id.clone();
+                let id = task_id.clone();
                 let cost = resp.cost;
                 blocking(store, move |c| {
-                    serp_results::insert_batch(c, &task_id, &resp.items)?;
-                    serp_tasks::mark_fetched(c, &task_id, cost)?;
+                    serp_results::insert_batch(c, &id, &resp.items)?;
+                    serp_tasks::mark_fetched(c, &id, cost)?;
                     Ok(())
                 })
                 .await?;
             }
             Err(e) => {
-                tracing::warn!(task_id = %task.task_id, error = %e, "task_get failed");
-                let task_id = task.task_id.clone();
+                tracing::warn!(task_id = %task_id, error = %e, "task_get failed");
+                let id = task_id.clone();
                 let msg = e.to_string();
-                blocking(store, move |c| {
-                    serp_tasks::record_attempt(c, &task_id, Some(&msg))
-                })
-                .await?;
+                blocking(store, move |c| serp_tasks::record_attempt(c, &id, Some(&msg))).await?;
             }
         }
     }

--- a/apps/dataforseo-app/src-tauri/src/tasks/poller.rs
+++ b/apps/dataforseo-app/src-tauri/src/tasks/poller.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use futures::stream::{self, StreamExt};
+use futures::stream::{self, StreamExt, TryStreamExt};
 use tokio::task;
 use tokio::time;
 
@@ -55,11 +55,11 @@ async fn poll_once(api: &Arc<ApiClient>, store: &Arc<Store>) -> Result<()> {
         return Ok(());
     }
 
-    // Fetch results concurrently. Each future yields (task_id, Result<resp>);
-    // the rate-limiter inside ApiClient still serialises actual HTTP requests
-    // up to the configured per-family rate, so this is bounded throughput
-    // with parallelised waiting.
-    let fetches = stream::iter(ready.into_iter().map(|t| {
+    // Fetch and persist concurrently. Each network result is handed to a
+    // DB write as soon as it arrives, so a slow task_get does not stall
+    // persistence of the others. Per-family rate-limiting still bounds
+    // absolute throughput inside ApiClient.
+    stream::iter(ready.into_iter().map(|t| {
         let api = api.clone();
         async move {
             let r = api.serp_google_organic_task_get_regular(&t.task_id).await;
@@ -67,13 +67,11 @@ async fn poll_once(api: &Arc<ApiClient>, store: &Arc<Store>) -> Result<()> {
         }
     }))
     .buffer_unordered(TASK_GET_CONCURRENCY)
-    .collect::<Vec<_>>()
-    .await;
-
-    for (task_id, result) in fetches {
+    .map(Ok::<_, AppError>)
+    .try_for_each(|(task_id, result)| async move {
         match result {
             Ok(resp) => {
-                let id = task_id.clone();
+                let id = task_id;
                 let cost = resp.cost;
                 blocking(store, move |c| {
                     serp_results::insert_batch(c, &id, &resp.items)?;
@@ -84,12 +82,14 @@ async fn poll_once(api: &Arc<ApiClient>, store: &Arc<Store>) -> Result<()> {
             }
             Err(e) => {
                 tracing::warn!(task_id = %task_id, error = %e, "task_get failed");
-                let id = task_id.clone();
+                let id = task_id;
                 let msg = e.to_string();
                 blocking(store, move |c| serp_tasks::record_attempt(c, &id, Some(&msg))).await?;
             }
         }
-    }
+        Ok(())
+    })
+    .await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes the four follow-ups deferred from the simplify pass on PR #23. Stacked on PR #23.

## What changes

### 1. commands::ledger::run_with_ledger

New helper that wraps the cost-estimate → API call → ledger skeleton repeated across all six commands. Times the call, records duration_ms on every row, and writes a ledger row on **both success and failure paths**. Failure rows carry the upstream API status_code (when present) and the error message, so the Usage page now surfaces failed calls alongside successful ones.

### 2. Failure recording across all six commands

keywords_search_volume, keywords_suggestions, keywords_related, keywords_for_domain, keywords_ranked, serp_live all go through run_with_ledger and therefore record failures. The two ad-hoc helpers (record_labs_call, record_ledger_entry) are deleted — net ~70 lines removed from commands/keywords.rs.

### 3. Mode enum in LedgerEntry + endpoint name constants

- LedgerEntry.mode is now Mode (typed enum) instead of &str. ledger::record converts via Mode::as_str() at the SQL layer.
- domain::endpoints exports stable string constants for every ledger endpoint name. Eliminates the eight scattered string literals that were the stringly-typed coupling between commands and the Usage page's group-by.
- errors::AppError gains api_status_code() so the failure ledger row can carry the upstream code for AppError::Api.

### 4. Bounded-concurrency task_get in the poller

tasks::poller::poll_once uses futures::stream::buffer_unordered with concurrency = 8 to fetch ready tasks in parallel. The per-family rate-limiter (SerpTask: 2000 rpm) still bounds absolute throughput; this just parallelises the waiting time. Adds futures = "0.3" dep.

## Out of scope, deferred

- ts-rs-driven type generation replacing the manual src/lib/tauri.ts interfaces — requires wiring cargo build to actually emit the .ts files, which is a build-pipeline change better as its own PR.

## Test plan
- [ ] cd apps/dataforseo-app/src-tauri && cargo check.
- [ ] Trigger a forced failure on /keywords/volume (clear credentials, run a query) and verify a row with error="..." appears in the Usage page recent calls.
- [ ] Submit a 50-keyword bulk SERP batch. Watch the poller log: ready tasks should be fetched in parallel (visible by overlapping debug spans on Family::SerpTask).
- [ ] Verify api_calls.mode column contains "live" / "standard" lowercase strings (no enum-debug noise like "Live").


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_