### PR TITLE
FEAT: CSV and JSON export on every results table

### DIFF
--- a/apps/dataforseo-app/src/components/ExportMenu.tsx
+++ b/apps/dataforseo-app/src/components/ExportMenu.tsx
@@ -1,0 +1,71 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { useState } from "react";
+
+import { downloadCsv, downloadJson, timestampedFilename } from "../lib/export";
+
+interface Props<T> {
+  /// Stem of the filename — gets a timestamp + extension appended.
+  filenameStem: string;
+  rows: T[];
+  columns: ColumnDef<T, unknown>[];
+  disabled?: boolean;
+}
+
+export default function ExportMenu<T>({ filenameStem, rows, columns, disabled }: Props<T>) {
+  const [open, setOpen] = useState(false);
+
+  const onCsv = () => {
+    downloadCsv(rows, columns, timestampedFilename(filenameStem, "csv"));
+    setOpen(false);
+  };
+
+  const onJson = () => {
+    downloadJson(rows, timestampedFilename(filenameStem, "json"));
+    setOpen(false);
+  };
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        disabled={disabled || rows.length === 0}
+        className="rounded border px-2 py-1 text-xs disabled:opacity-50"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        Export ▾
+      </button>
+      {open && !disabled && (
+        <>
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setOpen(false)}
+            aria-hidden
+          />
+          <div
+            role="menu"
+            className="absolute right-0 z-20 mt-1 min-w-[140px] rounded border bg-white py-1 text-sm shadow"
+          >
+            <button
+              type="button"
+              role="menuitem"
+              onClick={onCsv}
+              className="block w-full px-3 py-1.5 text-left hover:bg-slate-100"
+            >
+              Download CSV
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={onJson}
+              className="block w-full px-3 py-1.5 text-left hover:bg-slate-100"
+            >
+              Download JSON
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/dataforseo-app/src/lib/export.test.ts
+++ b/apps/dataforseo-app/src/lib/export.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { downloadCsv } from "./export";
+
+describe("downloadCsv", () => {
+  it("escapes commas, quotes, and newlines per RFC 4180", () => {
+    let captured = "";
+    const origCreate = URL.createObjectURL;
+    const origRevoke = URL.revokeObjectURL;
+    const origAppend = document.body.appendChild.bind(document.body);
+    URL.createObjectURL = (blob: Blob) => {
+      blob.text().then((t) => {
+        captured = t;
+      });
+      return "blob:test";
+    };
+    URL.revokeObjectURL = () => undefined;
+    document.body.appendChild = (node: Node) => {
+      if (node instanceof HTMLAnchorElement) {
+        // skip the actual click — text is captured via createObjectURL
+      }
+      return origAppend(node);
+    };
+
+    const rows = [
+      { kw: "hello, world", vol: 100 },
+      { kw: 'with "quotes"', vol: 200 },
+      { kw: "line\nbreak", vol: 300 },
+    ];
+    downloadCsv(
+      rows,
+      [
+        { header: "Keyword", accessorKey: "kw" },
+        { header: "Volume", accessorKey: "vol" },
+      ],
+      "test.csv",
+    );
+
+    URL.createObjectURL = origCreate;
+    URL.revokeObjectURL = origRevoke;
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(captured).toContain('"hello, world"');
+        expect(captured).toContain('"with ""quotes"""');
+        expect(captured).toContain('"line\nbreak"');
+        resolve();
+      }, 10);
+    });
+  });
+
+  it("falls back to column id when header is not a string", () => {
+    let captured = "";
+    URL.createObjectURL = (blob: Blob) => {
+      blob.text().then((t) => {
+        captured = t;
+      });
+      return "blob:test";
+    };
+    URL.revokeObjectURL = () => undefined;
+
+    downloadCsv(
+      [{ a: 1 }],
+      [{ id: "computed", header: () => null, accessorKey: "a" }],
+      "test.csv",
+    );
+
+    return new Promise<void>((resolve) => {
+      setTimeout(() => {
+        expect(captured.split("\n")[0]).toBe("computed");
+        resolve();
+      }, 10);
+    });
+  });
+});

--- a/apps/dataforseo-app/src/lib/export.ts
+++ b/apps/dataforseo-app/src/lib/export.ts
@@ -15,16 +15,19 @@ function csvEscape(value: string): string {
 }
 
 /// Resolve a column header to a string. tanstack-table allows the header to
-/// be a string, function, or React node; we want the same label that's
-/// painted in the UI for free-form headers and fall back to the column id.
+/// be a string, function, or React node; for non-string headers fall back
+/// to the explicit `id`, and finally to `accessorKey` (which tanstack-table
+/// itself uses as the implicit id when neither is given).
 function headerLabel<T>(column: ColumnDef<T, unknown>): string {
   if (typeof column.header === "string") return column.header;
-  return String(column.id ?? "");
+  const accessorKey = (column as { accessorKey?: string }).accessorKey;
+  return String(column.id ?? accessorKey ?? "");
 }
 
 /// Resolve a row's value for one column. Honors accessorFn first (custom
-/// projections), then accessorKey (declarative field access). Returns ""
-/// for unresolved cells so the CSV stays well-formed.
+/// projections), then accessorKey (with dotted-path support — tanstack-table
+/// supports nested keys like "user.profile.name"). Returns "" for unresolved
+/// cells so the CSV stays well-formed.
 function cellValue<T>(column: ColumnDef<T, unknown>, row: T, index: number): string {
   type WithFn = { accessorFn?: (row: T, index: number) => unknown };
   type WithKey = { accessorKey?: string };
@@ -35,7 +38,13 @@ function cellValue<T>(column: ColumnDef<T, unknown>, row: T, index: number): str
   }
   const key = (column as WithKey).accessorKey;
   if (typeof key === "string") {
-    const v = (row as Record<string, unknown>)[key];
+    const v = key
+      .split(".")
+      .reduce<unknown>(
+        (acc, part) =>
+          acc == null ? undefined : (acc as Record<string, unknown>)[part],
+        row,
+      );
     return v == null ? "" : String(v);
   }
   return "";
@@ -61,8 +70,10 @@ export function downloadCsv<T>(
   const header = columns.map((c) => csvEscape(headerLabel(c))).join(",");
   const body = rows
     .map((r, i) => columns.map((c) => csvEscape(cellValue(c, r, i))).join(","))
-    .join("\n");
-  triggerBlobDownload(`${header}\n${body}\n`, filename, "text/csv;charset=utf-8");
+    .join("\r\n");
+  // RFC 4180 says records are CRLF-delimited. Excel/Sheets/Numbers all
+  // accept LF too, but CRLF is the safe default for downstream tooling.
+  triggerBlobDownload(`${header}\r\n${body}\r\n`, filename, "text/csv;charset=utf-8");
 }
 
 export function downloadJson<T>(rows: T[], filename: string): void {
@@ -70,10 +81,12 @@ export function downloadJson<T>(rows: T[], filename: string): void {
 }
 
 /// Stamp a filename with a sortable timestamp so users can collect repeat
-/// exports without overwriting.
+/// exports without overwriting. Sanitises the stem so it cannot blow up on
+/// Windows: drops any of <>:"/\|?* and collapses runs of whitespace.
 export function timestampedFilename(stem: string, ext: "csv" | "json"): string {
+  const safe = stem.replace(/[<>:"/\\|?*\s]+/g, "-").replace(/^-+|-+$/g, "") || "export";
   const now = new Date();
   const pad = (n: number) => n.toString().padStart(2, "0");
   const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
-  return `${stem}-${stamp}.${ext}`;
+  return `${safe}-${stamp}.${ext}`;
 }

--- a/apps/dataforseo-app/src/lib/export.ts
+++ b/apps/dataforseo-app/src/lib/export.ts
@@ -1,0 +1,79 @@
+//! Client-side CSV / JSON export for ResultsTable.
+//!
+//! Frontend-only — all data is already in React state by the time the user
+//! can click "Download". The Rust backend has nothing to do here.
+
+import type { ColumnDef } from "@tanstack/react-table";
+
+/// RFC 4180-ish CSV cell escape: wrap in double-quotes if the value contains
+/// comma, quote, or newline; embedded quotes are doubled.
+function csvEscape(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/// Resolve a column header to a string. tanstack-table allows the header to
+/// be a string, function, or React node; we want the same label that's
+/// painted in the UI for free-form headers and fall back to the column id.
+function headerLabel<T>(column: ColumnDef<T, unknown>): string {
+  if (typeof column.header === "string") return column.header;
+  return String(column.id ?? "");
+}
+
+/// Resolve a row's value for one column. Honors accessorFn first (custom
+/// projections), then accessorKey (declarative field access). Returns ""
+/// for unresolved cells so the CSV stays well-formed.
+function cellValue<T>(column: ColumnDef<T, unknown>, row: T, index: number): string {
+  type WithFn = { accessorFn?: (row: T, index: number) => unknown };
+  type WithKey = { accessorKey?: string };
+  const fn = (column as WithFn).accessorFn;
+  if (typeof fn === "function") {
+    const v = fn(row, index);
+    return v == null ? "" : String(v);
+  }
+  const key = (column as WithKey).accessorKey;
+  if (typeof key === "string") {
+    const v = (row as Record<string, unknown>)[key];
+    return v == null ? "" : String(v);
+  }
+  return "";
+}
+
+function triggerBlobDownload(content: string, filename: string, mime: string): void {
+  const blob = new Blob([content], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+export function downloadCsv<T>(
+  rows: T[],
+  columns: ColumnDef<T, unknown>[],
+  filename: string,
+): void {
+  const header = columns.map((c) => csvEscape(headerLabel(c))).join(",");
+  const body = rows
+    .map((r, i) => columns.map((c) => csvEscape(cellValue(c, r, i))).join(","))
+    .join("\n");
+  triggerBlobDownload(`${header}\n${body}\n`, filename, "text/csv;charset=utf-8");
+}
+
+export function downloadJson<T>(rows: T[], filename: string): void {
+  triggerBlobDownload(JSON.stringify(rows, null, 2), filename, "application/json");
+}
+
+/// Stamp a filename with a sortable timestamp so users can collect repeat
+/// exports without overwriting.
+export function timestampedFilename(stem: string, ext: "csv" | "json"): string {
+  const now = new Date();
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  return `${stem}-${stamp}.${ext}`;
+}

--- a/apps/dataforseo-app/src/routes/domain/KeywordsForSiteTab.tsx
+++ b/apps/dataforseo-app/src/routes/domain/KeywordsForSiteTab.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import ResultsTable from "../../components/ResultsTable";
 import { formatCount, formatUsd } from "../../lib/format";
 import { tauriApi, type LabsBatch, type LabsKeyword } from "../../lib/tauri";
@@ -76,8 +77,15 @@ export default function KeywordsForSiteTab({ target }: Props) {
       </div>
 
       {batch && (
-        <div className="text-xs text-slate-500">
-          {batch.items.length} rows · actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+        <div className="flex items-center justify-between text-xs text-slate-500">
+          <span>
+            {batch.items.length} rows · actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+          </span>
+          <ExportMenu
+            filenameStem="keywords-for-domain"
+            rows={batch.items}
+            columns={columns}
+          />
         </div>
       )}
 

--- a/apps/dataforseo-app/src/routes/domain/RankedKeywordsTab.tsx
+++ b/apps/dataforseo-app/src/routes/domain/RankedKeywordsTab.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import ResultsTable from "../../components/ResultsTable";
 import { formatCount, formatUsd } from "../../lib/format";
 import { tauriApi, type RankedBatch, type RankedKeyword } from "../../lib/tauri";
@@ -109,8 +110,15 @@ export default function RankedKeywordsTab({ target }: Props) {
       </div>
 
       {batch && (
-        <div className="text-xs text-slate-500">
-          {batch.items.length} ranked keywords · actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+        <div className="flex items-center justify-between text-xs text-slate-500">
+          <span>
+            {batch.items.length} ranked keywords · actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+          </span>
+          <ExportMenu
+            filenameStem="ranked-keywords"
+            rows={batch.items}
+            columns={columns}
+          />
         </div>
       )}
 

--- a/apps/dataforseo-app/src/routes/keywords/RelatedTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/RelatedTab.tsx
@@ -19,6 +19,7 @@ export default function RelatedTab() {
     <SeedTab
       title="Related Keywords"
       description="Ideas pulled from Googles 'searches related to' section. Higher depth costs more."
+      exportFilenameStem="related-keywords"
       costAction={costAction}
       extraControls={
         <label className="flex flex-col gap-1 text-sm">

--- a/apps/dataforseo-app/src/routes/keywords/SeedTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/SeedTab.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import ResultsTable from "../../components/ResultsTable";
 import type { CostAction } from "../../lib/cost";
 import { formatCount, formatUsd } from "../../lib/format";
@@ -14,6 +15,7 @@ const DEFAULT_LANGUAGE = "de";
 interface Props {
   title: string;
   description: string;
+  exportFilenameStem: string;
   /// Cost preview action. Pass a stable (memoized) value from the parent so
   /// the CostPreview doesn't re-render on every keystroke in the seed input.
   costAction: CostAction;
@@ -22,7 +24,14 @@ interface Props {
   run: (seed: string) => Promise<LabsBatch>;
 }
 
-export default function SeedTab({ title, description, costAction, extraControls, run }: Props) {
+export default function SeedTab({
+  title,
+  description,
+  exportFilenameStem,
+  costAction,
+  extraControls,
+  run,
+}: Props) {
   const [seed, setSeed] = useState("");
   const [busy, setBusy] = useState(false);
   const [batch, setBatch] = useState<LabsBatch | null>(null);
@@ -112,8 +121,15 @@ export default function SeedTab({ title, description, costAction, extraControls,
       </div>
 
       {batch && (
-        <div className="text-xs text-slate-500">
-          {batch.items.length} rows · actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+        <div className="flex items-center justify-between text-xs text-slate-500">
+          <span>
+            {batch.items.length} rows · actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+          </span>
+          <ExportMenu
+            filenameStem={exportFilenameStem}
+            rows={batch.items}
+            columns={columns}
+          />
         </div>
       )}
 

--- a/apps/dataforseo-app/src/routes/keywords/SuggestionsTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/SuggestionsTab.tsx
@@ -12,6 +12,7 @@ export default function SuggestionsTab() {
     <SeedTab
       title="Keyword Suggestions"
       description="Long-tail keywords that contain the seed term, ranked by search volume."
+      exportFilenameStem="keyword-suggestions"
       costAction={SUGGESTIONS_COST}
       run={(seed) =>
         tauriApi.keywordsSuggestions({

--- a/apps/dataforseo-app/src/routes/keywords/VolumeTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/VolumeTab.tsx
@@ -4,6 +4,7 @@ import toast from "react-hot-toast";
 
 import BulkKeywordInput, { parseKeywords } from "../../components/BulkKeywordInput";
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import ResultsTable from "../../components/ResultsTable";
 import { formatCount, formatUsd } from "../../lib/format";
 import { tauriApi, type KeywordVolume, type KeywordVolumeBatch } from "../../lib/tauri";
@@ -111,9 +112,16 @@ export default function VolumeTab() {
       </div>
 
       {batch && (
-        <div className="text-xs text-slate-500">
-          {batch.items.length} rows · {batch.cache_hits} from cache · {batch.fresh} freshly fetched ·
-          actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+        <div className="flex items-center justify-between text-xs text-slate-500">
+          <span>
+            {batch.items.length} rows · {batch.cache_hits} from cache · {batch.fresh} freshly fetched ·
+            actual cost {formatUsd(batch.cost_usd)} (estimated {formatUsd(batch.estimated_usd)})
+          </span>
+          <ExportMenu
+            filenameStem="keyword-volume"
+            rows={batch.items}
+            columns={columns}
+          />
         </div>
       )}
 

--- a/apps/dataforseo-app/src/routes/serp/QuickTab.tsx
+++ b/apps/dataforseo-app/src/routes/serp/QuickTab.tsx
@@ -1,7 +1,9 @@
+import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import { formatUsd } from "../../lib/format";
 import { tauriApi, type SerpLiveBatch, type SerpResultItem } from "../../lib/tauri";
 
@@ -31,6 +33,18 @@ export default function QuickTab() {
   const [batch, setBatch] = useState<SerpLiveBatch | null>(null);
 
   const trimmed = keyword.trim();
+
+  const exportColumns = useMemo<ColumnDef<SerpResultItem, unknown>[]>(
+    () => [
+      { id: "rank_absolute", header: "Position", accessorKey: "rank_absolute" },
+      { id: "kind", header: "Type", accessorKey: "kind" },
+      { id: "domain", header: "Domain", accessorKey: "domain" },
+      { id: "url", header: "URL", accessorKey: "url" },
+      { id: "title", header: "Title", accessorKey: "title" },
+      { id: "description", header: "Description", accessorKey: "description" },
+    ],
+    [],
+  );
 
   const costAction = useMemo(
     () =>
@@ -115,9 +129,16 @@ export default function QuickTab() {
       </div>
 
       {batch && (
-        <div className="text-xs text-slate-500">
-          {batch.items.length} items for &ldquo;{batch.keyword}&rdquo; · actual cost {formatUsd(batch.cost_usd)} (estimated{" "}
-          {formatUsd(batch.estimated_usd)})
+        <div className="flex items-center justify-between text-xs text-slate-500">
+          <span>
+            {batch.items.length} items for &ldquo;{batch.keyword}&rdquo; · actual cost {formatUsd(batch.cost_usd)} (estimated{" "}
+            {formatUsd(batch.estimated_usd)})
+          </span>
+          <ExportMenu
+            filenameStem={`serp-${batch.keyword.replace(/\s+/g, "-").toLowerCase()}`}
+            rows={batch.items}
+            columns={exportColumns}
+          />
         </div>
       )}
 

--- a/apps/dataforseo-app/src/routes/serp/QuickTab.tsx
+++ b/apps/dataforseo-app/src/routes/serp/QuickTab.tsx
@@ -135,7 +135,7 @@ export default function QuickTab() {
             {formatUsd(batch.estimated_usd)})
           </span>
           <ExportMenu
-            filenameStem={`serp-${batch.keyword.replace(/\s+/g, "-").toLowerCase()}`}
+            filenameStem={`serp-${batch.keyword}`}
             rows={batch.items}
             columns={exportColumns}
           />


### PR DESCRIPTION
## Summary

First milestone from docs/DATAFORSEO_VECDOOR_AI_CHAT_PLAN.md. Frontend-only — every results table the user already sees can now be saved as CSV or JSON via a small Export dropdown. Stacked on PR #24.

## What works after this PR

Every tab with a result set has an "Export" dropdown next to the summary line, with Download CSV and Download JSON. Filenames are auto-stamped with a timestamp so repeated exports do not collide.

Wired into:
- /keywords Volume, Suggestions, Related
- /domain Keywords-for-site, Ranked-keywords
- /serp Quick (lightweight export columns declared inline so the cards-style render stays untouched)

## Backend changes

None. Pure frontend.

## Frontend changes

- src/lib/export.ts: csvEscape (RFC 4180), header/cell value resolution (handles function headers and accessorFn vs accessorKey columns), triggerBlobDownload, downloadCsv, downloadJson, timestampedFilename.
- src/components/ExportMenu.tsx: outside-click dismissable dropdown, disabled when there are no rows.
- src/lib/export.test.ts: vitest covering RFC 4180 quoting and the column-id fallback for non-string headers.

## Out of scope, deferred

- Tasks page (Bulk SERP nested per-task results) — needs its own flatten-or-multi-file export shape.
- Usage page (api_calls ledger) — wants to live with the rest of the audit log, will pick up an export in the AI cost ledger UI milestone.
- XLSX and Google Sheets — Phase 2 per the plan.

## Test plan
- [ ] cd apps/dataforseo-app && npm run test (export.test.ts).
- [ ] npm run tauri:dev: run a Volume query, click Export -> Download CSV. Open in Excel; verify "comma, in keyword" round-trips. Click Download JSON; verify valid JSON in the browser.
- [ ] Repeat on Suggestions, Related, Keywords-for-Domain, Ranked, SERP Quick. Verify filename stems and timestamps.


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_