### PR TITLE
FEAT: AI cost ledger UI on the Usage page

### DIFF
--- a/apps/dataforseo-app/src-tauri/src/commands/ledger.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/ledger.rs
@@ -7,7 +7,7 @@ use crate::domain::cost::{self, CostAction};
 use crate::domain::types::Mode;
 use crate::errors::{AppError, Result};
 use crate::state::AppState;
-use crate::store::ledger::{self, CallLogRow, LedgerEntry, UsageSummary};
+use crate::store::ledger::{self, AiCallRow, AiUsageSummary, CallLogRow, LedgerEntry, UsageSummary};
 use crate::store::Store;
 
 #[tauri::command]
@@ -120,6 +120,34 @@ pub async fn get_usage_summary(
     let store = state.store.clone();
     task::spawn_blocking(move || -> Result<_> {
         store.with_conn(|c| ledger::summary(c, days))
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn get_ai_recent_calls(
+    state: State<'_, AppState>,
+    limit: u32,
+) -> Result<Vec<AiCallRow>> {
+    let store = state.store.clone();
+    task::spawn_blocking(move || -> Result<_> {
+        store.with_conn(|c| ledger::ai_recent(c, limit))
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn get_ai_usage_summary(
+    state: State<'_, AppState>,
+    days: u32,
+) -> Result<AiUsageSummary> {
+    let store = state.store.clone();
+    task::spawn_blocking(move || -> Result<_> {
+        store.with_conn(|c| ledger::ai_summary(c, days))
     })
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -40,6 +40,8 @@ pub fn run() {
             commands::ledger::estimate_cost,
             commands::ledger::get_recent_calls,
             commands::ledger::get_usage_summary,
+            commands::ledger::get_ai_recent_calls,
+            commands::ledger::get_ai_usage_summary,
             commands::keywords::keywords_search_volume,
             commands::keywords::keywords_suggestions,
             commands::keywords::keywords_related,

--- a/apps/dataforseo-app/src-tauri/src/store/ledger.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/ledger.rs
@@ -131,3 +131,110 @@ pub fn summary(conn: &mut Connection, days: u32) -> Result<UsageSummary> {
         by_endpoint,
     })
 }
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct AiCallRow {
+    pub ts: String,
+    pub provider: String,
+    pub model: String,
+    pub purpose: String,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cost_usd: f64,
+    pub duration_ms: Option<i64>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct AiUsageByModel {
+    pub provider: String,
+    pub model: String,
+    pub call_count: i64,
+    pub input_tokens: i64,
+    pub output_tokens: i64,
+    pub cost_usd: f64,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct AiUsageSummary {
+    pub days: i32,
+    pub total_calls: i64,
+    pub total_cost_usd: f64,
+    pub total_input_tokens: i64,
+    pub total_output_tokens: i64,
+    pub by_model: Vec<AiUsageByModel>,
+}
+
+pub fn ai_recent(conn: &mut Connection, limit: u32) -> Result<Vec<AiCallRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT ts, provider, model, purpose, input_tokens, output_tokens,
+                cost_usd, duration_ms, error
+           FROM ai_calls
+          ORDER BY ts DESC
+          LIMIT $1",
+    )?;
+    let rows = stmt.query_map([limit as i64], |row| {
+        Ok(AiCallRow {
+            ts: row.get(0)?,
+            provider: row.get(1)?,
+            model: row.get(2)?,
+            purpose: row.get(3)?,
+            input_tokens: row.get(4)?,
+            output_tokens: row.get(5)?,
+            cost_usd: row.get(6)?,
+            duration_ms: row.get(7)?,
+            error: row.get(8)?,
+        })
+    })?;
+    Ok(rows.collect::<duckdb::Result<Vec<_>>>()?)
+}
+
+pub fn ai_summary(conn: &mut Connection, days: u32) -> Result<AiUsageSummary> {
+    let days_i = days as i64;
+
+    let (total_calls, total_cost_usd, total_input_tokens, total_output_tokens): (i64, f64, i64, i64) =
+        conn.query_row(
+            "SELECT COUNT(*),
+                    COALESCE(SUM(cost_usd), 0.0),
+                    COALESCE(SUM(input_tokens), 0),
+                    COALESCE(SUM(output_tokens), 0)
+               FROM ai_calls
+              WHERE ts >= CURRENT_TIMESTAMP - INTERVAL '1 day' * $1",
+            [days_i],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )?;
+
+    let mut stmt = conn.prepare(
+        "SELECT provider, model, COUNT(*),
+                COALESCE(SUM(input_tokens), 0),
+                COALESCE(SUM(output_tokens), 0),
+                COALESCE(SUM(cost_usd), 0.0)
+           FROM ai_calls
+          WHERE ts >= CURRENT_TIMESTAMP - INTERVAL '1 day' * $1
+          GROUP BY provider, model
+          ORDER BY 6 DESC",
+    )?;
+    let rows = stmt.query_map([days_i], |row| {
+        Ok(AiUsageByModel {
+            provider: row.get(0)?,
+            model: row.get(1)?,
+            call_count: row.get(2)?,
+            input_tokens: row.get(3)?,
+            output_tokens: row.get(4)?,
+            cost_usd: row.get(5)?,
+        })
+    })?;
+    let by_model: Vec<AiUsageByModel> = rows.collect::<duckdb::Result<_>>()?;
+
+    Ok(AiUsageSummary {
+        days: days as i32,
+        total_calls,
+        total_cost_usd,
+        total_input_tokens,
+        total_output_tokens,
+        by_model,
+    })
+}

--- a/apps/dataforseo-app/src-tauri/src/store/ledger.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/ledger.rs
@@ -199,8 +199,8 @@ pub fn ai_summary(conn: &mut Connection, days: u32) -> Result<AiUsageSummary> {
         conn.query_row(
             "SELECT COUNT(*),
                     COALESCE(SUM(cost_usd), 0.0),
-                    COALESCE(SUM(input_tokens), 0),
-                    COALESCE(SUM(output_tokens), 0)
+                    COALESCE(SUM(input_tokens)::BIGINT, 0),
+                    COALESCE(SUM(output_tokens)::BIGINT, 0)
                FROM ai_calls
               WHERE ts >= CURRENT_TIMESTAMP - INTERVAL '1 day' * $1",
             [days_i],
@@ -209,8 +209,8 @@ pub fn ai_summary(conn: &mut Connection, days: u32) -> Result<AiUsageSummary> {
 
     let mut stmt = conn.prepare(
         "SELECT provider, model, COUNT(*),
-                COALESCE(SUM(input_tokens), 0),
-                COALESCE(SUM(output_tokens), 0),
+                COALESCE(SUM(input_tokens)::BIGINT, 0),
+                COALESCE(SUM(output_tokens)::BIGINT, 0),
                 COALESCE(SUM(cost_usd), 0.0)
            FROM ai_calls
           WHERE ts >= CURRENT_TIMESTAMP - INTERVAL '1 day' * $1

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -103,6 +103,12 @@ export const tauriApi = {
   getUsageSummary: (args: { days: number }) =>
     invoke<UsageSummary>("get_usage_summary", args),
 
+  getAiRecentCalls: (args: { limit: number }) =>
+    invoke<AiCallRow[]>("get_ai_recent_calls", args),
+
+  getAiUsageSummary: (args: { days: number }) =>
+    invoke<AiUsageSummary>("get_ai_usage_summary", args),
+
   aiProviderStatus: () => invoke<AiProviderStatus[]>("ai_provider_status"),
 
   aiSaveProviderKey: (args: { provider: string; apiKey: string }) =>
@@ -189,6 +195,36 @@ export interface UsageSummary {
   total_cost_usd: number;
   total_estimated_usd: number;
   by_endpoint: UsageByEndpoint[];
+}
+
+export interface AiCallRow {
+  ts: string;
+  provider: string;
+  model: string;
+  purpose: string;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+  duration_ms: number | null;
+  error: string | null;
+}
+
+export interface AiUsageByModel {
+  provider: string;
+  model: string;
+  call_count: number;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+}
+
+export interface AiUsageSummary {
+  days: number;
+  total_calls: number;
+  total_cost_usd: number;
+  total_input_tokens: number;
+  total_output_tokens: number;
+  by_model: AiUsageByModel[];
 }
 
 export interface TaskBatchId {

--- a/apps/dataforseo-app/src/routes/UsagePage.tsx
+++ b/apps/dataforseo-app/src/routes/UsagePage.tsx
@@ -1,214 +1,45 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import toast from "react-hot-toast";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
+import { useState } from "react";
 
-import { formatUsd } from "../lib/format";
-import {
-  tauriApi,
-  type CallLogRow,
-  type UsageSummary,
-} from "../lib/tauri";
+import AiTab from "./usage/AiTab";
+import DataforseoTab from "./usage/DataforseoTab";
 
-const RANGE_OPTIONS = [
-  { value: 7, label: "7 days" },
-  { value: 30, label: "30 days" },
-  { value: 90, label: "90 days" },
+const TABS = [
+  { id: "dataforseo", label: "DataForSEO" },
+  { id: "ai", label: "AI Chat" },
 ] as const;
 
+type TabId = (typeof TABS)[number]["id"];
+
 export default function UsagePage() {
-  const [days, setDays] = useState<number>(30);
-  const [summary, setSummary] = useState<UsageSummary | null>(null);
-  const [recent, setRecent] = useState<CallLogRow[] | null>(null);
-  const [busy, setBusy] = useState(false);
-
-  // Summary depends on `days`; the recent-calls list does not (it always
-  // shows the last 50). Splitting the two effects avoids re-fetching the
-  // call log on every range change.
-  const refreshSummary = useCallback(async () => {
-    setBusy(true);
-    try {
-      setSummary(await tauriApi.getUsageSummary({ days }));
-    } catch (e) {
-      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
-    } finally {
-      setBusy(false);
-    }
-  }, [days]);
-
-  const refreshRecent = useCallback(async () => {
-    try {
-      setRecent(await tauriApi.getRecentCalls({ limit: 50 }));
-    } catch (e) {
-      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
-    }
-  }, []);
-
-  const refresh = useCallback(async () => {
-    await Promise.all([refreshSummary(), refreshRecent()]);
-  }, [refreshSummary, refreshRecent]);
-
-  useEffect(() => {
-    refreshSummary();
-  }, [refreshSummary]);
-
-  useEffect(() => {
-    refreshRecent();
-  }, [refreshRecent]);
-
-  const chartData = useMemo(
-    () =>
-      summary?.by_endpoint.map((e) => ({
-        endpoint: e.endpoint,
-        cost: Number(e.cost_usd.toFixed(4)),
-        calls: e.call_count,
-      })) ?? [],
-    [summary],
-  );
-
-  const estimateAccuracy = useMemo(() => {
-    if (!summary || summary.total_estimated_usd === 0) return null;
-    const drift = summary.total_cost_usd - summary.total_estimated_usd;
-    const pct = (drift / summary.total_estimated_usd) * 100;
-    return { drift, pct };
-  }, [summary]);
-
+  const [active, setActive] = useState<TabId>("dataforseo");
   return (
     <section className="flex flex-col gap-6">
-      <header className="flex items-center justify-between">
-        <div>
-          <h2 className="text-xl font-semibold">Usage</h2>
-          <p className="text-sm text-slate-600">
-            Spend by endpoint and recent API calls. Auto-refresh on range change.
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          <select
-            value={days}
-            onChange={(e) => setDays(parseInt(e.target.value, 10))}
-            className="rounded border px-2 py-1 text-sm"
-          >
-            {RANGE_OPTIONS.map((o) => (
-              <option key={o.value} value={o.value}>
-                {o.label}
-              </option>
-            ))}
-          </select>
-          <button
-            type="button"
-            onClick={refresh}
-            disabled={busy}
-            className="rounded border px-3 py-1 text-sm disabled:opacity-50"
-          >
-            Refresh
-          </button>
-        </div>
+      <header>
+        <h2 className="text-xl font-semibold">Usage</h2>
+        <p className="text-sm text-slate-600">
+          Spend audit. DataForSEO API and AI provider calls are tracked
+          separately so you can see where the money is going.
+        </p>
       </header>
+      <nav className="flex gap-1 border-b">
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActive(tab.id)}
+            className={`-mb-px border-b-2 px-3 py-1.5 text-sm transition-colors ${
+              active === tab.id
+                ? "border-slate-800 font-medium text-slate-800"
+                : "border-transparent text-slate-500 hover:text-slate-700"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <Stat
-          label="Total spend"
-          value={summary ? formatUsd(summary.total_cost_usd) : "—"}
-          subline={`${summary?.total_calls ?? 0} calls`}
-        />
-        <Stat
-          label="Estimated"
-          value={summary ? formatUsd(summary.total_estimated_usd) : "—"}
-          subline={
-            estimateAccuracy
-              ? `${estimateAccuracy.drift >= 0 ? "+" : ""}${formatUsd(estimateAccuracy.drift)} drift (${estimateAccuracy.pct.toFixed(1)}%)`
-              : "—"
-          }
-        />
-        <Stat
-          label="Endpoints used"
-          value={summary ? String(summary.by_endpoint.length) : "—"}
-          subline="distinct"
-        />
-      </div>
-
-      <div className="rounded border bg-white p-3">
-        <h3 className="mb-2 text-sm font-medium text-slate-700">Spend by endpoint</h3>
-        {chartData.length === 0 ? (
-          <div className="py-12 text-center text-sm text-slate-500">
-            No calls recorded in the selected range.
-          </div>
-        ) : (
-          <ResponsiveContainer width="100%" height={240}>
-            <BarChart data={chartData} margin={{ top: 10, right: 16, bottom: 30, left: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="endpoint" angle={-15} textAnchor="end" height={60} fontSize={11} />
-              <YAxis tickFormatter={(v) => formatUsd(v)} fontSize={11} />
-              <Tooltip
-                formatter={(value: number, name) => [
-                  name === "cost" ? formatUsd(value) : value,
-                  name === "cost" ? "spend" : "calls",
-                ]}
-              />
-              <Bar dataKey="cost" fill="#475569" />
-            </BarChart>
-          </ResponsiveContainer>
-        )}
-      </div>
-
-      <div className="rounded border bg-white">
-        <h3 className="border-b px-3 py-2 text-sm font-medium text-slate-700">
-          Recent calls (last 50)
-        </h3>
-        {recent == null || recent.length === 0 ? (
-          <div className="p-8 text-center text-sm text-slate-500">No calls yet.</div>
-        ) : (
-          <table className="min-w-full text-sm">
-            <thead className="bg-slate-50 text-left text-xs">
-              <tr>
-                <th className="px-3 py-2">Time</th>
-                <th className="px-3 py-2">Endpoint</th>
-                <th className="px-3 py-2">Mode</th>
-                <th className="px-3 py-2 text-right">Cost</th>
-                <th className="px-3 py-2 text-right">Est.</th>
-                <th className="px-3 py-2 text-right">Items</th>
-                <th className="px-3 py-2 text-right">ms</th>
-              </tr>
-            </thead>
-            <tbody>
-              {recent.map((r, i) => (
-                <tr key={`${r.ts}-${i}`} className="border-t">
-                  <td className="px-3 py-1.5 font-mono text-xs">{r.ts}</td>
-                  <td className="px-3 py-1.5 font-mono text-xs">{r.endpoint}</td>
-                  <td className="px-3 py-1.5 text-xs">{r.mode}</td>
-                  <td className="px-3 py-1.5 text-right font-mono">{formatUsd(r.cost_usd)}</td>
-                  <td className="px-3 py-1.5 text-right font-mono text-slate-500">
-                    {r.estimated_usd != null ? formatUsd(r.estimated_usd) : "—"}
-                  </td>
-                  <td className="px-3 py-1.5 text-right font-mono text-slate-500">
-                    {r.request_size ?? "—"}
-                  </td>
-                  <td className="px-3 py-1.5 text-right font-mono text-slate-500">
-                    {r.duration_ms ?? "—"}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
+      {active === "dataforseo" && <DataforseoTab />}
+      {active === "ai" && <AiTab />}
     </section>
-  );
-}
-
-function Stat({ label, value, subline }: { label: string; value: string; subline?: string }) {
-  return (
-    <div className="rounded border bg-white p-3">
-      <div className="text-xs text-slate-500">{label}</div>
-      <div className="mt-1 text-2xl font-semibold tabular-nums">{value}</div>
-      {subline && <div className="mt-1 text-xs text-slate-500">{subline}</div>}
-    </div>
   );
 }

--- a/apps/dataforseo-app/src/routes/usage/AiTab.tsx
+++ b/apps/dataforseo-app/src/routes/usage/AiTab.tsx
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { formatCount, formatUsd } from "../../lib/format";
+import {
+  tauriApi,
+  type AiCallRow,
+  type AiUsageSummary,
+} from "../../lib/tauri";
+import Stat from "./Stat";
+
+const RANGE_OPTIONS = [
+  { value: 7, label: "7 days" },
+  { value: 30, label: "30 days" },
+  { value: 90, label: "90 days" },
+] as const;
+
+export default function AiTab() {
+  const [days, setDays] = useState<number>(30);
+  const [summary, setSummary] = useState<AiUsageSummary | null>(null);
+  const [recent, setRecent] = useState<AiCallRow[] | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refreshSummary = useCallback(async () => {
+    setBusy(true);
+    try {
+      setSummary(await tauriApi.getAiUsageSummary({ days }));
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }, [days]);
+
+  const refreshRecent = useCallback(async () => {
+    try {
+      setRecent(await tauriApi.getAiRecentCalls({ limit: 50 }));
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    await Promise.all([refreshSummary(), refreshRecent()]);
+  }, [refreshSummary, refreshRecent]);
+
+  useEffect(() => {
+    refreshSummary();
+  }, [refreshSummary]);
+
+  useEffect(() => {
+    refreshRecent();
+  }, [refreshRecent]);
+
+  const chartData = useMemo(
+    () =>
+      summary?.by_model.map((m) => ({
+        model: `${m.provider}/${m.model}`,
+        cost: Number(m.cost_usd.toFixed(4)),
+        calls: m.call_count,
+      })) ?? [],
+    [summary],
+  );
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-end gap-2">
+        <select
+          value={days}
+          onChange={(e) => setDays(parseInt(e.target.value, 10))}
+          className="rounded border px-2 py-1 text-sm"
+        >
+          {RANGE_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={busy}
+          className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <Stat
+          label="Total spend"
+          value={summary ? formatUsd(summary.total_cost_usd) : "—"}
+          subline={`${summary?.total_calls ?? 0} calls`}
+        />
+        <Stat
+          label="Tokens in / out"
+          value={
+            summary
+              ? `${formatCount(summary.total_input_tokens)} / ${formatCount(summary.total_output_tokens)}`
+              : "—"
+          }
+          subline="combined for the range"
+        />
+        <Stat
+          label="Models used"
+          value={summary ? String(summary.by_model.length) : "—"}
+          subline="distinct"
+        />
+      </div>
+
+      <div className="rounded border bg-white p-3">
+        <h3 className="mb-2 text-sm font-medium text-slate-700">Spend by model</h3>
+        {chartData.length === 0 ? (
+          <div className="py-12 text-center text-sm text-slate-500">
+            No AI calls recorded in the selected range. Try /chat with a Quick Action attached.
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={240}>
+            <BarChart data={chartData} margin={{ top: 10, right: 16, bottom: 30, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="model" angle={-15} textAnchor="end" height={60} fontSize={11} />
+              <YAxis tickFormatter={(v) => formatUsd(v)} fontSize={11} />
+              <Tooltip
+                formatter={(value: number, name) => [
+                  name === "cost" ? formatUsd(value) : value,
+                  name === "cost" ? "spend" : "calls",
+                ]}
+              />
+              <Bar dataKey="cost" fill="#7c3aed" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      <div className="rounded border bg-white">
+        <h3 className="border-b px-3 py-2 text-sm font-medium text-slate-700">
+          Recent AI calls (last 50)
+        </h3>
+        {recent == null || recent.length === 0 ? (
+          <div className="p-8 text-center text-sm text-slate-500">No AI calls yet.</div>
+        ) : (
+          <table className="min-w-full text-sm">
+            <thead className="bg-slate-50 text-left text-xs">
+              <tr>
+                <th className="px-3 py-2">Time</th>
+                <th className="px-3 py-2">Provider</th>
+                <th className="px-3 py-2">Model</th>
+                <th className="px-3 py-2">Purpose</th>
+                <th className="px-3 py-2 text-right">In</th>
+                <th className="px-3 py-2 text-right">Out</th>
+                <th className="px-3 py-2 text-right">Cost</th>
+                <th className="px-3 py-2 text-right">ms</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recent.map((r, i) => (
+                <tr
+                  key={`${r.ts}-${i}`}
+                  className={`border-t ${r.error ? "bg-rose-50" : ""}`}
+                  title={r.error ?? undefined}
+                >
+                  <td className="px-3 py-1.5 font-mono text-xs">{r.ts}</td>
+                  <td className="px-3 py-1.5 text-xs">{r.provider}</td>
+                  <td className="px-3 py-1.5 font-mono text-xs">{r.model}</td>
+                  <td className="px-3 py-1.5 text-xs">{r.purpose}</td>
+                  <td className="px-3 py-1.5 text-right font-mono text-slate-500">
+                    {formatCount(r.input_tokens)}
+                  </td>
+                  <td className="px-3 py-1.5 text-right font-mono text-slate-500">
+                    {formatCount(r.output_tokens)}
+                  </td>
+                  <td className="px-3 py-1.5 text-right font-mono">{formatUsd(r.cost_usd)}</td>
+                  <td className="px-3 py-1.5 text-right font-mono text-slate-500">
+                    {r.duration_ms ?? "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/dataforseo-app/src/routes/usage/DataforseoTab.tsx
+++ b/apps/dataforseo-app/src/routes/usage/DataforseoTab.tsx
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { formatUsd } from "../../lib/format";
+import {
+  tauriApi,
+  type CallLogRow,
+  type UsageSummary,
+} from "../../lib/tauri";
+import Stat from "./Stat";
+
+const RANGE_OPTIONS = [
+  { value: 7, label: "7 days" },
+  { value: 30, label: "30 days" },
+  { value: 90, label: "90 days" },
+] as const;
+
+export default function DataforseoTab() {
+  const [days, setDays] = useState<number>(30);
+  const [summary, setSummary] = useState<UsageSummary | null>(null);
+  const [recent, setRecent] = useState<CallLogRow[] | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refreshSummary = useCallback(async () => {
+    setBusy(true);
+    try {
+      setSummary(await tauriApi.getUsageSummary({ days }));
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }, [days]);
+
+  const refreshRecent = useCallback(async () => {
+    try {
+      setRecent(await tauriApi.getRecentCalls({ limit: 50 }));
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    }
+  }, []);
+
+  const refresh = useCallback(async () => {
+    await Promise.all([refreshSummary(), refreshRecent()]);
+  }, [refreshSummary, refreshRecent]);
+
+  useEffect(() => {
+    refreshSummary();
+  }, [refreshSummary]);
+
+  useEffect(() => {
+    refreshRecent();
+  }, [refreshRecent]);
+
+  const chartData = useMemo(
+    () =>
+      summary?.by_endpoint.map((e) => ({
+        endpoint: e.endpoint,
+        cost: Number(e.cost_usd.toFixed(4)),
+        calls: e.call_count,
+      })) ?? [],
+    [summary],
+  );
+
+  const estimateAccuracy = useMemo(() => {
+    if (!summary || summary.total_estimated_usd === 0) return null;
+    const drift = summary.total_cost_usd - summary.total_estimated_usd;
+    const pct = (drift / summary.total_estimated_usd) * 100;
+    return { drift, pct };
+  }, [summary]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-end gap-2">
+        <select
+          value={days}
+          onChange={(e) => setDays(parseInt(e.target.value, 10))}
+          className="rounded border px-2 py-1 text-sm"
+        >
+          {RANGE_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={busy}
+          className="rounded border px-3 py-1 text-sm disabled:opacity-50"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <Stat
+          label="Total spend"
+          value={summary ? formatUsd(summary.total_cost_usd) : "—"}
+          subline={`${summary?.total_calls ?? 0} calls`}
+        />
+        <Stat
+          label="Estimated"
+          value={summary ? formatUsd(summary.total_estimated_usd) : "—"}
+          subline={
+            estimateAccuracy
+              ? `${estimateAccuracy.drift >= 0 ? "+" : ""}${formatUsd(estimateAccuracy.drift)} drift (${estimateAccuracy.pct.toFixed(1)}%)`
+              : "—"
+          }
+        />
+        <Stat
+          label="Endpoints used"
+          value={summary ? String(summary.by_endpoint.length) : "—"}
+          subline="distinct"
+        />
+      </div>
+
+      <div className="rounded border bg-white p-3">
+        <h3 className="mb-2 text-sm font-medium text-slate-700">Spend by endpoint</h3>
+        {chartData.length === 0 ? (
+          <div className="py-12 text-center text-sm text-slate-500">
+            No calls recorded in the selected range.
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={240}>
+            <BarChart data={chartData} margin={{ top: 10, right: 16, bottom: 30, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="endpoint" angle={-15} textAnchor="end" height={60} fontSize={11} />
+              <YAxis tickFormatter={(v) => formatUsd(v)} fontSize={11} />
+              <Tooltip
+                formatter={(value: number, name) => [
+                  name === "cost" ? formatUsd(value) : value,
+                  name === "cost" ? "spend" : "calls",
+                ]}
+              />
+              <Bar dataKey="cost" fill="#475569" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      <div className="rounded border bg-white">
+        <h3 className="border-b px-3 py-2 text-sm font-medium text-slate-700">
+          Recent calls (last 50)
+        </h3>
+        {recent == null || recent.length === 0 ? (
+          <div className="p-8 text-center text-sm text-slate-500">No calls yet.</div>
+        ) : (
+          <table className="min-w-full text-sm">
+            <thead className="bg-slate-50 text-left text-xs">
+              <tr>
+                <th className="px-3 py-2">Time</th>
+                <th className="px-3 py-2">Endpoint</th>
+                <th className="px-3 py-2">Mode</th>
+                <th className="px-3 py-2 text-right">Cost</th>
+                <th className="px-3 py-2 text-right">Est.</th>
+                <th className="px-3 py-2 text-right">Items</th>
+                <th className="px-3 py-2 text-right">ms</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recent.map((r, i) => (
+                <tr key={`${r.ts}-${i}`} className="border-t">
+                  <td className="px-3 py-1.5 font-mono text-xs">{r.ts}</td>
+                  <td className="px-3 py-1.5 font-mono text-xs">{r.endpoint}</td>
+                  <td className="px-3 py-1.5 text-xs">{r.mode}</td>
+                  <td className="px-3 py-1.5 text-right font-mono">{formatUsd(r.cost_usd)}</td>
+                  <td className="px-3 py-1.5 text-right font-mono text-slate-500">
+                    {r.estimated_usd != null ? formatUsd(r.estimated_usd) : "—"}
+                  </td>
+                  <td className="px-3 py-1.5 text-right font-mono text-slate-500">
+                    {r.request_size ?? "—"}
+                  </td>
+                  <td className="px-3 py-1.5 text-right font-mono text-slate-500">
+                    {r.duration_ms ?? "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/dataforseo-app/src/routes/usage/Stat.tsx
+++ b/apps/dataforseo-app/src/routes/usage/Stat.tsx
@@ -1,0 +1,15 @@
+interface Props {
+  label: string;
+  value: string;
+  subline?: string;
+}
+
+export default function Stat({ label, value, subline }: Props) {
+  return (
+    <div className="rounded border bg-white p-3">
+      <div className="text-xs text-slate-500">{label}</div>
+      <div className="mt-1 text-2xl font-semibold tabular-nums">{value}</div>
+      {subline && <div className="mt-1 text-xs text-slate-500">{subline}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes the cost-transparency story. The Usage page now has two tabs — DataForSEO (existing) and AI Chat (new) — both rendering the same KPI tile + bar-chart + recent-calls-table layout against the appropriate ledger table. Stacked on PR #29.

Uses the ai_calls rows that PR #28 has been writing for every chat_send; no new schema.

## What works after this PR

/usage tab AI Chat shows:
- KPI tiles: total spend, tokens in/out, distinct models used.
- Recharts bar chart: spend grouped by provider/model.
- Recent-50-calls table with token columns. Failed calls render rose-tinted with the full error string in the row title attribute.

## Backend changes (src-tauri/)

- store::ledger gains AiCallRow, AiUsageByModel, AiUsageSummary types and ai_recent / ai_summary helpers (mirroring recent / summary for api_calls).
- commands::ledger gains get_ai_recent_calls + get_ai_usage_summary, registered in lib.rs.

## Frontend changes (src/)

- UsagePage refactored into a thin tabbed shell.
- routes/usage/DataforseoTab.tsx — extracted from the previous UsagePage, no behavioral change.
- routes/usage/AiTab.tsx — new.
- routes/usage/Stat.tsx — shared KPI tile lifted out so both tabs render identical cards.
- lib/tauri.ts — two new wrappers + types.

## Test plan
- [ ] cd apps/dataforseo-app/src-tauri && cargo check.
- [ ] After running a few chat_send calls in /chat, navigate to /usage -> AI Chat tab. Verify totals match a manual `SELECT count(*), sum(cost_usd) FROM ai_calls` against the local DuckDB.
- [ ] Trigger a chat failure (bad API key) and confirm a rose-tinted row shows up in the Recent table.


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_