### PR TITLE
FEAT: Keyword-set Compare page

### DIFF
--- a/apps/dataforseo-app/src/App.tsx
+++ b/apps/dataforseo-app/src/App.tsx
@@ -1,6 +1,7 @@
 import { Link, Navigate, Route, Routes } from "react-router-dom";
 
 import ChatPage from "./routes/ChatPage";
+import ComparePage from "./routes/ComparePage";
 import KeywordsPage from "./routes/KeywordsPage";
 import SerpPage from "./routes/SerpPage";
 import DomainPage from "./routes/DomainPage";
@@ -12,6 +13,7 @@ const navItems = [
   { to: "/keywords", label: "Keywords" },
   { to: "/serp", label: "SERP" },
   { to: "/domain", label: "Domain" },
+  { to: "/compare", label: "Compare" },
   { to: "/tasks", label: "Tasks" },
   { to: "/chat", label: "Chat" },
   { to: "/usage", label: "Usage" },
@@ -41,6 +43,7 @@ export default function App() {
           <Route path="/keywords/*" element={<KeywordsPage />} />
           <Route path="/serp/*" element={<SerpPage />} />
           <Route path="/domain/*" element={<DomainPage />} />
+          <Route path="/compare" element={<ComparePage />} />
           <Route path="/tasks" element={<TasksPage />} />
           <Route path="/chat" element={<ChatPage />} />
           <Route path="/chat/:sessionId" element={<ChatPage />} />

--- a/apps/dataforseo-app/src/routes/ComparePage.tsx
+++ b/apps/dataforseo-app/src/routes/ComparePage.tsx
@@ -1,0 +1,290 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+
+import BulkKeywordInput, { parseKeywords } from "../components/BulkKeywordInput";
+import ChatWithResultsButton from "../components/ChatWithResultsButton";
+import CostPreview from "../components/CostPreview";
+import ExportMenu from "../components/ExportMenu";
+import ResultsTable from "../components/ResultsTable";
+import { formatCount, formatUsd } from "../lib/format";
+import { tauriApi, type KeywordVolume } from "../lib/tauri";
+
+const DEFAULT_LOCATION = 2276;
+const DEFAULT_LANGUAGE = "de";
+
+interface CompareRow {
+  keyword: string;
+  set: "common" | "a" | "b";
+  volume_a: number | null;
+  volume_b: number | null;
+  cpc_a: number | null;
+  cpc_b: number | null;
+  competition_a: string | null;
+  competition_b: string | null;
+}
+
+export default function ComparePage() {
+  const [rawA, setRawA] = useState("");
+  const [rawB, setRawB] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [rows, setRows] = useState<CompareRow[]>([]);
+  const [bucket, setBucket] = useState<"common" | "a" | "b">("common");
+
+  const keywordsA = useMemo(() => parseKeywords(rawA), [rawA]);
+  const keywordsB = useMemo(() => parseKeywords(rawB), [rawB]);
+  const totalUnique = useMemo(
+    () => new Set([...keywordsA, ...keywordsB]).size,
+    [keywordsA, keywordsB],
+  );
+  const overLimit =
+    keywordsA.length > 1000 || keywordsB.length > 1000 || totalUnique > 1000;
+
+  async function onCompare() {
+    if (
+      keywordsA.length === 0 ||
+      keywordsB.length === 0 ||
+      keywordsA.length > 1000 ||
+      keywordsB.length > 1000
+    ) {
+      return;
+    }
+    setBusy(true);
+    try {
+      // Cache deduplicates the request per side; if the user pastes the same
+      // keyword in both sets, the second call is a free cache hit.
+      const [batchA, batchB] = await Promise.all([
+        tauriApi.keywordsSearchVolume({
+          keywords: keywordsA,
+          locationCode: DEFAULT_LOCATION,
+          languageCode: DEFAULT_LANGUAGE,
+          useCache: true,
+        }),
+        tauriApi.keywordsSearchVolume({
+          keywords: keywordsB,
+          locationCode: DEFAULT_LOCATION,
+          languageCode: DEFAULT_LANGUAGE,
+          useCache: true,
+        }),
+      ]);
+
+      const mapA = new Map(batchA.items.map((it: KeywordVolume) => [it.keyword, it]));
+      const mapB = new Map(batchB.items.map((it: KeywordVolume) => [it.keyword, it]));
+
+      const all = new Set<string>([...mapA.keys(), ...mapB.keys()]);
+      const compareRows: CompareRow[] = Array.from(all).map((keyword) => {
+        const a = mapA.get(keyword);
+        const b = mapB.get(keyword);
+        const set: CompareRow["set"] = a && b ? "common" : a ? "a" : "b";
+        return {
+          keyword,
+          set,
+          volume_a: a?.search_volume ?? null,
+          volume_b: b?.search_volume ?? null,
+          cpc_a: a?.cpc ?? null,
+          cpc_b: b?.cpc ?? null,
+          competition_a: a?.competition ?? null,
+          competition_b: b?.competition ?? null,
+        };
+      });
+      compareRows.sort((x, y) => {
+        const xv = Math.max(x.volume_a ?? 0, x.volume_b ?? 0);
+        const yv = Math.max(y.volume_a ?? 0, y.volume_b ?? 0);
+        return yv - xv;
+      });
+      setRows(compareRows);
+      const cost = batchA.cost_usd + batchB.cost_usd;
+      toast.success(
+        `${compareRows.length} keywords compared (${formatUsd(cost)} fresh, rest from cache)`,
+      );
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const counts = useMemo(() => {
+    let common = 0;
+    let onlyA = 0;
+    let onlyB = 0;
+    for (const r of rows) {
+      if (r.set === "common") common++;
+      else if (r.set === "a") onlyA++;
+      else onlyB++;
+    }
+    return { common, onlyA, onlyB };
+  }, [rows]);
+
+  const filtered = useMemo(
+    () => rows.filter((r) => r.set === bucket),
+    [rows, bucket],
+  );
+
+  const columns = useMemo<ColumnDef<CompareRow, unknown>[]>(
+    () => [
+      {
+        header: "Keyword",
+        accessorKey: "keyword",
+        cell: (ctx) => <span className="font-mono">{ctx.getValue<string>()}</span>,
+      },
+      {
+        header: "Volume A",
+        accessorKey: "volume_a",
+        cell: (ctx) => {
+          const v = ctx.getValue<number | null>();
+          return v != null ? formatCount(v) : "—";
+        },
+      },
+      {
+        header: "Volume B",
+        accessorKey: "volume_b",
+        cell: (ctx) => {
+          const v = ctx.getValue<number | null>();
+          return v != null ? formatCount(v) : "—";
+        },
+      },
+      {
+        header: "CPC A",
+        accessorKey: "cpc_a",
+        cell: (ctx) => {
+          const v = ctx.getValue<number | null>();
+          return v != null ? formatUsd(v) : "—";
+        },
+      },
+      {
+        header: "CPC B",
+        accessorKey: "cpc_b",
+        cell: (ctx) => {
+          const v = ctx.getValue<number | null>();
+          return v != null ? formatUsd(v) : "—";
+        },
+      },
+    ],
+    [],
+  );
+
+  return (
+    <section className="flex flex-col gap-6">
+      <header>
+        <h2 className="text-xl font-semibold">Compare keyword sets</h2>
+        <p className="text-sm text-slate-600">
+          Paste two lists of keywords, see what overlaps and what's unique to
+          each side. Volume + CPC data uses the existing search-volume cache,
+          so repeated comparisons are free for keywords already fetched.
+        </p>
+      </header>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_1fr_320px]">
+        <div>
+          <h3 className="mb-2 text-sm font-medium text-slate-700">Set A</h3>
+          <BulkKeywordInput value={rawA} onChange={setRawA} disabled={busy} />
+        </div>
+        <div>
+          <h3 className="mb-2 text-sm font-medium text-slate-700">Set B</h3>
+          <BulkKeywordInput value={rawB} onChange={setRawB} disabled={busy} />
+        </div>
+        <div className="flex flex-col gap-3">
+          <CostPreview
+            action={{
+              kind: "KeywordsSearchVolume",
+              count: totalUnique,
+              mode: "live",
+            }}
+            details={[
+              `${keywordsA.length} in A, ${keywordsB.length} in B (${totalUnique} unique)`,
+              `Location ${DEFAULT_LOCATION}, Language ${DEFAULT_LANGUAGE}`,
+              "Cache reused per keyword",
+            ]}
+            disabled={
+              busy ||
+              keywordsA.length === 0 ||
+              keywordsB.length === 0 ||
+              overLimit
+            }
+          />
+          <button
+            type="button"
+            onClick={onCompare}
+            disabled={
+              busy ||
+              keywordsA.length === 0 ||
+              keywordsB.length === 0 ||
+              overLimit
+            }
+            className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+          >
+            {busy ? "Comparing…" : "Compare"}
+          </button>
+        </div>
+      </div>
+
+      {rows.length > 0 && (
+        <>
+          <div className="flex flex-wrap items-center gap-2">
+            <BucketTab
+              label={`Common (${counts.common})`}
+              active={bucket === "common"}
+              onClick={() => setBucket("common")}
+            />
+            <BucketTab
+              label={`Only A (${counts.onlyA})`}
+              active={bucket === "a"}
+              onClick={() => setBucket("a")}
+            />
+            <BucketTab
+              label={`Only B (${counts.onlyB})`}
+              active={bucket === "b"}
+              onClick={() => setBucket("b")}
+            />
+            <div className="ml-auto flex gap-2">
+              <ChatWithResultsButton
+                rows={filtered}
+                summary={`${filtered.length} ${bucket} keywords from compare`}
+              />
+              <ExportMenu
+                filenameStem={`compare-${bucket}`}
+                rows={filtered}
+                columns={columns}
+              />
+            </div>
+          </div>
+
+          <ResultsTable
+            data={filtered}
+            columns={columns}
+            emptyMessage="No keywords in this bucket."
+          />
+        </>
+      )}
+
+      {rows.length === 0 && !busy && (
+        <div className="rounded border bg-white p-8 text-center text-sm text-slate-500">
+          Paste keywords into both sides and click Compare.
+        </div>
+      )}
+    </section>
+  );
+}
+
+function BucketTab({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded border px-3 py-1 text-xs ${
+        active ? "border-slate-800 bg-slate-100" : "hover:bg-slate-50"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/dataforseo-app/src/routes/ComparePage.tsx
+++ b/apps/dataforseo-app/src/routes/ComparePage.tsx
@@ -41,50 +41,43 @@ export default function ComparePage() {
     keywordsA.length > 1000 || keywordsB.length > 1000 || totalUnique > 1000;
 
   async function onCompare() {
-    if (
-      keywordsA.length === 0 ||
-      keywordsB.length === 0 ||
-      keywordsA.length > 1000 ||
-      keywordsB.length > 1000
-    ) {
+    if (keywordsA.length === 0 || keywordsB.length === 0 || overLimit) {
       return;
     }
     setBusy(true);
     try {
-      // Cache deduplicates the request per side; if the user pastes the same
-      // keyword in both sets, the second call is a free cache hit.
-      const [batchA, batchB] = await Promise.all([
-        tauriApi.keywordsSearchVolume({
-          keywords: keywordsA,
-          locationCode: DEFAULT_LOCATION,
-          languageCode: DEFAULT_LANGUAGE,
-          useCache: true,
-        }),
-        tauriApi.keywordsSearchVolume({
-          keywords: keywordsB,
-          locationCode: DEFAULT_LOCATION,
-          languageCode: DEFAULT_LANGUAGE,
-          useCache: true,
-        }),
-      ]);
+      // One request for the union — search_volume's cache already
+      // deduplicates per (keyword, location, language) so paying for
+      // overlap is impossible. Iterating the input keyword sets (not
+      // the response) means missing API rows still show up in the
+      // result with null volume instead of vanishing.
+      const allUnique = Array.from(new Set([...keywordsA, ...keywordsB]));
+      const batch = await tauriApi.keywordsSearchVolume({
+        keywords: allUnique,
+        locationCode: DEFAULT_LOCATION,
+        languageCode: DEFAULT_LANGUAGE,
+        useCache: true,
+      });
 
-      const mapA = new Map(batchA.items.map((it: KeywordVolume) => [it.keyword, it]));
-      const mapB = new Map(batchB.items.map((it: KeywordVolume) => [it.keyword, it]));
+      const resultMap = new Map(
+        batch.items.map((it: KeywordVolume) => [it.keyword, it]),
+      );
+      const setA = new Set(keywordsA);
+      const setB = new Set(keywordsB);
 
-      const all = new Set<string>([...mapA.keys(), ...mapB.keys()]);
-      const compareRows: CompareRow[] = Array.from(all).map((keyword) => {
-        const a = mapA.get(keyword);
-        const b = mapB.get(keyword);
-        const set: CompareRow["set"] = a && b ? "common" : a ? "a" : "b";
+      const compareRows: CompareRow[] = allUnique.map((keyword) => {
+        const data = resultMap.get(keyword);
+        const inA = setA.has(keyword);
+        const inB = setB.has(keyword);
         return {
           keyword,
-          set,
-          volume_a: a?.search_volume ?? null,
-          volume_b: b?.search_volume ?? null,
-          cpc_a: a?.cpc ?? null,
-          cpc_b: b?.cpc ?? null,
-          competition_a: a?.competition ?? null,
-          competition_b: b?.competition ?? null,
+          set: inA && inB ? "common" : inA ? "a" : "b",
+          volume_a: inA ? (data?.search_volume ?? null) : null,
+          volume_b: inB ? (data?.search_volume ?? null) : null,
+          cpc_a: inA ? (data?.cpc ?? null) : null,
+          cpc_b: inB ? (data?.cpc ?? null) : null,
+          competition_a: inA ? (data?.competition ?? null) : null,
+          competition_b: inB ? (data?.competition ?? null) : null,
         };
       });
       compareRows.sort((x, y) => {
@@ -93,9 +86,8 @@ export default function ComparePage() {
         return yv - xv;
       });
       setRows(compareRows);
-      const cost = batchA.cost_usd + batchB.cost_usd;
       toast.success(
-        `${compareRows.length} keywords compared (${formatUsd(cost)} fresh, rest from cache)`,
+        `${compareRows.length} keywords compared (${formatUsd(batch.cost_usd)} fresh, rest from cache)`,
       );
     } catch (e) {
       toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);


### PR DESCRIPTION
## Summary

Implements the keyword-set Compare milestone from the vecdoor plan (Teil 2.B). Frontend-only — the existing keywords_search_volume command already does what the page needs, the cache makes repeated comparisons close to free. Stacked on PR #30.

## What works after this PR

/compare lets the user paste two keyword lists side by side, click Compare, and get three buckets:

- Common (in both sets) — useful for "what do my competitor and I both rank for"
- Only A — useful for "what do I have that they don't"
- Only B — useful for "what do they have that I don't"

Each bucket renders the same table (keyword, volume A, volume B, CPC A, CPC B). Export and "Chat with results" both honor the active bucket, so the user can drop the keyword-gap straight into Excel or into a Cluster prompt.

## Backend changes

None.

## Frontend changes

- routes/ComparePage.tsx — two BulkKeywordInputs + cost preview + three bucket tabs above ResultsTable. Volume is fetched via Promise.all + cache, so a keyword that appears in both sets only costs the user once.
- App.tsx — new /compare route + nav entry between Domain and Tasks.

## Test plan
- [ ] cd apps/dataforseo-app && npm run lint.
- [ ] In tauri:dev: paste 5 keywords on the left and 5 on the right with 2 in common. Click Compare. Confirm Common shows 2 rows, Only A shows 3, Only B shows 3, and the cost preview matches what api_calls records.
- [ ] Run the same comparison again — second run should report close-to-zero actual cost since everything is cached.


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_