### PR TITLE
FEAT: OpenAI as a second AI provider

### DIFF
--- a/apps/dataforseo-app/src-tauri/src/ai/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/ai/mod.rs
@@ -2,8 +2,9 @@
 //! docs/DATAFORSEO_VECDOOR_AI_CHAT_PLAN.md.
 
 pub mod anthropic;
-pub mod prompts;
 pub mod context;
+pub mod openai;
+pub mod prompts;
 
 use std::sync::Arc;
 

--- a/apps/dataforseo-app/src-tauri/src/ai/openai.rs
+++ b/apps/dataforseo-app/src-tauri/src/ai/openai.rs
@@ -1,0 +1,190 @@
+//! OpenAI implementation of AiClient. Talks to /v1/chat/completions.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::ai::{AiClient, ChatMessage, ChatResponse, Role, TokenUsage};
+use crate::errors::{AppError, Result};
+
+const OPENAI_API: &str = "https://api.openai.com/v1/chat/completions";
+
+/// Per-1M-token pricing keyed by model id prefix. Order matters —
+/// longer / more specific prefixes first.
+const PRICING: &[(&str, f64, f64)] = &[
+    ("gpt-4o-mini",   0.15,  0.60),
+    ("gpt-4o",        2.50, 10.00),
+    ("gpt-4.1-mini",  0.40,  1.60),
+    ("gpt-4.1",       2.00,  8.00),
+    ("o4-mini",       1.10,  4.40),
+];
+
+const FALLBACK_INPUT_PER_M: f64 = 2.50;
+const FALLBACK_OUTPUT_PER_M: f64 = 10.00;
+
+fn pricing_for(model: &str) -> (f64, f64) {
+    for (prefix, input, output) in PRICING {
+        if model.starts_with(prefix) {
+            return (*input, *output);
+        }
+    }
+    tracing::warn!(
+        model,
+        "no pricing entry for OpenAI model; falling back to gpt-4o rates",
+    );
+    (FALLBACK_INPUT_PER_M, FALLBACK_OUTPUT_PER_M)
+}
+
+pub struct OpenAiClient {
+    http: reqwest::Client,
+    api_key: String,
+    model: String,
+    max_tokens: u32,
+}
+
+impl OpenAiClient {
+    pub fn new(api_key: String, model: String) -> Self {
+        let http = reqwest::Client::builder()
+            .user_agent(concat!("dataforseo-app/", env!("CARGO_PKG_VERSION")))
+            .timeout(std::time::Duration::from_secs(120))
+            .build()
+            .expect("reqwest client builds with default config");
+        Self { http, api_key, model, max_tokens: 4096 }
+    }
+
+    async fn call(
+        &self,
+        system: Option<&str>,
+        messages: &[ChatMessage],
+    ) -> Result<ChatResponse> {
+        // OpenAI puts the system message in the same array as user/assistant
+        // turns (unlike Anthropic). Prepend the per-call system, then append
+        // the rest of the history filtered for stray Role::System rows.
+        let mut chat_messages: Vec<OpenAiMessage> = Vec::with_capacity(messages.len() + 1);
+        if let Some(s) = system {
+            chat_messages.push(OpenAiMessage { role: "system", content: s });
+        }
+        for m in messages {
+            let role = match m.role {
+                Role::User => "user",
+                Role::Assistant => "assistant",
+                // Skip embedded system rows — the per-call `system` arg is
+                // the source of truth.
+                Role::System => continue,
+            };
+            chat_messages.push(OpenAiMessage { role, content: &m.content });
+        }
+
+        if chat_messages.iter().all(|m| m.role == "system") {
+            return Err(AppError::Validation(
+                "chat requires at least one user/assistant message".into(),
+            ));
+        }
+
+        let body = OpenAiRequest {
+            model: &self.model,
+            max_tokens: self.max_tokens,
+            messages: chat_messages,
+        };
+
+        let resp = self
+            .http
+            .post(OPENAI_API)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(AppError::Api {
+                status_code: status.as_u16() as u32,
+                message: text,
+            });
+        }
+
+        let parsed: OpenAiResponse = resp.json().await?;
+
+        let content = parsed
+            .choices
+            .into_iter()
+            .next()
+            .map(|c| c.message.content)
+            .unwrap_or_default();
+
+        let (in_per_m, out_per_m) = pricing_for(&self.model);
+        let cost = (parsed.usage.prompt_tokens.max(0) as f64 / 1_000_000.0) * in_per_m
+            + (parsed.usage.completion_tokens.max(0) as f64 / 1_000_000.0) * out_per_m;
+
+        let usage = TokenUsage {
+            input_tokens: parsed.usage.prompt_tokens,
+            output_tokens: parsed.usage.completion_tokens,
+            cost_usd: cost,
+        };
+
+        Ok(ChatResponse { content, usage, model: parsed.model })
+    }
+}
+
+#[derive(Serialize)]
+struct OpenAiMessage<'a> {
+    role: &'a str,
+    content: &'a str,
+}
+
+#[derive(Serialize)]
+struct OpenAiRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    messages: Vec<OpenAiMessage<'a>>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponse {
+    model: String,
+    choices: Vec<OpenAiChoice>,
+    usage: OpenAiUsage,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChoice {
+    message: OpenAiResponseMessage,
+}
+
+#[derive(Deserialize)]
+struct OpenAiResponseMessage {
+    content: String,
+}
+
+#[derive(Deserialize)]
+struct OpenAiUsage {
+    prompt_tokens: i32,
+    completion_tokens: i32,
+}
+
+#[async_trait]
+impl AiClient for OpenAiClient {
+    fn provider_name(&self) -> &'static str {
+        "openai"
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+
+    async fn chat(&self, messages: &[ChatMessage]) -> Result<ChatResponse> {
+        let system = messages
+            .iter()
+            .find(|m| matches!(m.role, Role::System))
+            .map(|m| m.content.clone());
+        self.call(system.as_deref(), messages).await
+    }
+
+    async fn chat_with_system(
+        &self,
+        system: Option<&str>,
+        messages: &[ChatMessage],
+    ) -> Result<ChatResponse> {
+        self.call(system, messages).await
+    }
+}

--- a/apps/dataforseo-app/src-tauri/src/ai/openai.rs
+++ b/apps/dataforseo-app/src-tauri/src/ai/openai.rs
@@ -10,6 +10,10 @@ const OPENAI_API: &str = "https://api.openai.com/v1/chat/completions";
 
 /// Per-1M-token pricing keyed by model id prefix. Order matters —
 /// longer / more specific prefixes first.
+///
+/// Source: OpenAI's 2026 pricing page. `gpt-4.1*` (released Apr 2025),
+/// `o4-mini` (released Apr 2025), and the older `gpt-4o*` family all coexist;
+/// older 3.5/turbo SKUs are intentionally omitted (deprecated for new keys).
 const PRICING: &[(&str, f64, f64)] = &[
     ("gpt-4o-mini",   0.15,  0.60),
     ("gpt-4o",        2.50, 10.00),
@@ -113,6 +117,8 @@ impl OpenAiClient {
             .unwrap_or_default();
 
         let (in_per_m, out_per_m) = pricing_for(&self.model);
+        // .max(0) here is `Ord::max` (in the prelude), not a missing
+        // i32::max inherent — clamps stray negative token counts to 0.
         let cost = (parsed.usage.prompt_tokens.max(0) as f64 / 1_000_000.0) * in_per_m
             + (parsed.usage.completion_tokens.max(0) as f64 / 1_000_000.0) * out_per_m;
 

--- a/apps/dataforseo-app/src-tauri/src/commands/ai.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/ai.rs
@@ -8,8 +8,9 @@ use ts_rs::TS;
 
 use crate::ai::anthropic::AnthropicClient;
 use crate::ai::context::build_attachment_context;
+use crate::ai::openai::OpenAiClient;
 use crate::ai::prompts::{self, PromptTemplate, SYSTEM_PREAMBLE};
-use crate::ai::{ChatMessage, Role};
+use crate::ai::{AiClient, ChatMessage, Role};
 use crate::errors::{AppError, Result};
 use crate::secrets;
 use crate::state::AppState;
@@ -20,6 +21,12 @@ use crate::store::chat::{self, ChatSession, StoredChatMessage};
 /// catalogue) — not a typo for `claude-3-5-sonnet-latest`. Override per
 /// provider via the Settings page once a model picker exists.
 const DEFAULT_ANTHROPIC_MODEL: &str = "claude-sonnet-4-6";
+/// Default OpenAI model — gpt-4o-mini is the cheapest first-class option
+/// at the time of writing and works well as a sparmodus alternative to
+/// Anthropic for the prompt templates this app ships with.
+const DEFAULT_OPENAI_MODEL: &str = "gpt-4o-mini";
+
+const PROVIDERS: &[&str] = &["anthropic", "openai"];
 
 #[derive(Debug, Clone, Serialize, TS)]
 #[ts(export, export_to = "../src/lib/types/")]
@@ -33,17 +40,37 @@ pub struct AiProviderStatus {
 #[tracing::instrument(skip(state))]
 pub async fn ai_provider_status(state: State<'_, AppState>) -> Result<Vec<AiProviderStatus>> {
     let active = state.ai.get().await;
-    let anthropic_configured = active
-        .as_ref()
-        .map(|c| c.provider_name() == "anthropic")
-        .unwrap_or(false)
-        || secrets::load_ai_key("anthropic")?.is_some();
-    let model = active.as_ref().map(|c| c.model().to_string());
-    Ok(vec![AiProviderStatus {
-        provider: "anthropic",
-        configured: anthropic_configured,
-        model,
-    }])
+    let active_name = active.as_ref().map(|c| c.provider_name());
+    let active_model = active.as_ref().map(|c| c.model().to_string());
+
+    let mut out = Vec::with_capacity(PROVIDERS.len());
+    for provider in PROVIDERS {
+        let stored = secrets::load_ai_key(provider)?.is_some();
+        let is_active = active_name == Some(*provider);
+        out.push(AiProviderStatus {
+            provider,
+            configured: stored,
+            model: if is_active { active_model.clone() } else { None },
+        });
+    }
+    Ok(out)
+}
+
+fn build_client(provider: &str, api_key: String) -> Result<Arc<dyn AiClient>> {
+    match provider {
+        "anthropic" => Ok(Arc::new(AnthropicClient::new(
+            api_key,
+            DEFAULT_ANTHROPIC_MODEL.to_string(),
+        ))),
+        "openai" => Ok(Arc::new(OpenAiClient::new(
+            api_key,
+            DEFAULT_OPENAI_MODEL.to_string(),
+        ))),
+        other => Err(AppError::Validation(format!(
+            "provider {other} not implemented; supported: {}",
+            PROVIDERS.join(", "),
+        ))),
+    }
 }
 
 #[tauri::command]
@@ -53,14 +80,9 @@ pub async fn ai_save_provider_key(
     provider: String,
     api_key: String,
 ) -> Result<()> {
-    if provider != "anthropic" {
-        return Err(AppError::Validation(format!(
-            "provider {provider} not implemented yet — only 'anthropic' for now"
-        )));
-    }
+    let client = build_client(&provider, api_key.clone())?;
     secrets::save_ai_key(&provider, &api_key)?;
-    let client = AnthropicClient::new(api_key, DEFAULT_ANTHROPIC_MODEL.to_string());
-    state.ai.set(Arc::new(client)).await;
+    state.ai.set(client).await;
     Ok(())
 }
 
@@ -68,7 +90,28 @@ pub async fn ai_save_provider_key(
 #[tracing::instrument(skip(state))]
 pub async fn ai_clear_provider_key(state: State<'_, AppState>, provider: String) -> Result<()> {
     secrets::clear_ai_key(&provider)?;
-    state.ai.clear().await;
+    // Only drop the active client if it matches the provider being cleared —
+    // a key for a non-active provider just disappears from the keychain and
+    // the user keeps chatting on whatever is registered.
+    if let Some(active) = state.ai.get().await {
+        if active.provider_name() == provider {
+            state.ai.clear().await;
+        }
+    }
+    Ok(())
+}
+
+/// Switch the active provider to one whose key is already stored. Useful
+/// for the Settings page's provider radio so the user doesn't have to
+/// re-enter their key just to flip from Anthropic to OpenAI.
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn ai_set_active_provider(state: State<'_, AppState>, provider: String) -> Result<()> {
+    let key = secrets::load_ai_key(&provider)?.ok_or_else(|| {
+        AppError::Validation(format!("no API key stored for {provider}"))
+    })?;
+    let client = build_client(&provider, key)?;
+    state.ai.set(client).await;
     Ok(())
 }
 

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -54,6 +54,7 @@ pub fn run() {
             commands::ai::ai_provider_status,
             commands::ai::ai_save_provider_key,
             commands::ai::ai_clear_provider_key,
+            commands::ai::ai_set_active_provider,
             commands::ai::ai_prompt_templates,
             commands::ai::chat_new_session,
             commands::ai::chat_list_sessions,

--- a/apps/dataforseo-app/src-tauri/src/state.rs
+++ b/apps/dataforseo-app/src-tauri/src/state.rs
@@ -3,13 +3,14 @@ use std::sync::Arc;
 
 use tokio::sync::RwLock;
 
-use crate::ai::{anthropic::AnthropicClient, AiRegistry};
+use crate::ai::{anthropic::AnthropicClient, openai::OpenAiClient, AiClient, AiRegistry};
 use crate::api::client::ApiClient;
 use crate::ratelimit::Scheduler;
 use crate::secrets::{self, Credentials};
 use crate::store::Store;
 
 const DEFAULT_ANTHROPIC_MODEL: &str = "claude-sonnet-4-6";
+const DEFAULT_OPENAI_MODEL: &str = "gpt-4o-mini";
 
 pub struct AppState {
     pub credentials: Arc<RwLock<Option<Credentials>>>,
@@ -33,13 +34,27 @@ impl AppState {
         );
         let ai = Arc::new(AiRegistry::new());
 
-        // If we already have an Anthropic key in the keychain, register the
-        // client at startup so /chat works without a Settings round-trip.
-        if let Ok(Some(key)) = secrets::load_ai_key("anthropic") {
-            let client = AnthropicClient::new(key, DEFAULT_ANTHROPIC_MODEL.to_string());
+        // Restore an AI client from the keychain at startup so /chat works
+        // without a Settings round-trip. Anthropic wins when both providers
+        // are configured — the user can flip via the Settings page.
+        let initial_client: Option<Arc<dyn AiClient>> =
+            match secrets::load_ai_key("anthropic") {
+                Ok(Some(key)) => Some(Arc::new(AnthropicClient::new(
+                    key,
+                    DEFAULT_ANTHROPIC_MODEL.to_string(),
+                ))),
+                _ => match secrets::load_ai_key("openai") {
+                    Ok(Some(key)) => Some(Arc::new(OpenAiClient::new(
+                        key,
+                        DEFAULT_OPENAI_MODEL.to_string(),
+                    ))),
+                    _ => None,
+                },
+            };
+        if let Some(client) = initial_client {
             let ai_clone = ai.clone();
             tokio::spawn(async move {
-                ai_clone.set(Arc::new(client)).await;
+                ai_clone.set(client).await;
             });
         }
 

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -117,6 +117,9 @@ export const tauriApi = {
   aiClearProviderKey: (args: { provider: string }) =>
     invoke<void>("ai_clear_provider_key", args),
 
+  aiSetActiveProvider: (args: { provider: string }) =>
+    invoke<void>("ai_set_active_provider", args),
+
   aiPromptTemplates: () => invoke<PromptTemplate[]>("ai_prompt_templates"),
 
   chatNewSession: (args: {

--- a/apps/dataforseo-app/src/routes/SettingsPage.tsx
+++ b/apps/dataforseo-app/src/routes/SettingsPage.tsx
@@ -4,20 +4,33 @@ import toast from "react-hot-toast";
 import { formatUsd } from "../lib/format";
 import { tauriApi, type AiProviderStatus, type UserInfo } from "../lib/tauri";
 
+const PROVIDERS: { id: string; label: string; placeholder: string }[] = [
+  { id: "anthropic", label: "Anthropic Claude", placeholder: "sk-ant-..." },
+  { id: "openai", label: "OpenAI", placeholder: "sk-..." },
+];
+
 export default function SettingsPage() {
   const [login, setLogin] = useState("");
   const [password, setPassword] = useState("");
   const [info, setInfo] = useState<UserInfo | null>(null);
   const [busy, setBusy] = useState(false);
 
-  const [anthropicKey, setAnthropicKey] = useState("");
   const [aiStatus, setAiStatus] = useState<AiProviderStatus[]>([]);
+  const [keyDrafts, setKeyDrafts] = useState<Record<string, string>>({});
+
+  async function refreshAi() {
+    try {
+      setAiStatus(await tauriApi.aiProviderStatus());
+    } catch {
+      setAiStatus([]);
+    }
+  }
 
   useEffect(() => {
-    tauriApi.aiProviderStatus().then(setAiStatus).catch(() => undefined);
+    refreshAi();
   }, []);
 
-  async function onSave() {
+  async function onSaveDataforseo() {
     setBusy(true);
     try {
       await tauriApi.saveCredentials(login, password);
@@ -43,14 +56,15 @@ export default function SettingsPage() {
     }
   }
 
-  async function onSaveAnthropic() {
-    if (!anthropicKey.trim()) return;
+  async function onSaveAi(provider: string) {
+    const key = keyDrafts[provider]?.trim();
+    if (!key) return;
     setBusy(true);
     try {
-      await tauriApi.aiSaveProviderKey({ provider: "anthropic", apiKey: anthropicKey });
-      setAnthropicKey("");
-      setAiStatus(await tauriApi.aiProviderStatus());
-      toast.success("Anthropic key gespeichert");
+      await tauriApi.aiSaveProviderKey({ provider, apiKey: key });
+      setKeyDrafts((d) => ({ ...d, [provider]: "" }));
+      await refreshAi();
+      toast.success(`${provider} key gespeichert`);
     } catch (e) {
       toast.error(`Fehler: ${(e as { message?: string })?.message ?? e}`);
     } finally {
@@ -58,12 +72,12 @@ export default function SettingsPage() {
     }
   }
 
-  async function onClearAnthropic() {
+  async function onClearAi(provider: string) {
     setBusy(true);
     try {
-      await tauriApi.aiClearProviderKey({ provider: "anthropic" });
-      setAiStatus(await tauriApi.aiProviderStatus());
-      toast.success("Anthropic key entfernt");
+      await tauriApi.aiClearProviderKey({ provider });
+      await refreshAi();
+      toast.success(`${provider} key entfernt`);
     } catch (e) {
       toast.error(`Fehler: ${(e as { message?: string })?.message ?? e}`);
     } finally {
@@ -71,7 +85,20 @@ export default function SettingsPage() {
     }
   }
 
-  const anthropic = aiStatus.find((s) => s.provider === "anthropic");
+  async function onActivate(provider: string) {
+    setBusy(true);
+    try {
+      await tauriApi.aiSetActiveProvider({ provider });
+      await refreshAi();
+      toast.success(`${provider} aktiv`);
+    } catch (e) {
+      toast.error(`Fehler: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const activeProvider = aiStatus.find((s) => s.model != null)?.provider;
 
   return (
     <section className="flex max-w-md flex-col gap-8">
@@ -103,7 +130,7 @@ export default function SettingsPage() {
             <button
               type="button"
               disabled={busy || !login || !password}
-              onClick={onSave}
+              onClick={onSaveDataforseo}
               className="rounded bg-slate-800 px-3 py-1 text-sm text-white disabled:opacity-50"
             >
               Save
@@ -134,49 +161,79 @@ export default function SettingsPage() {
       <div>
         <h2 className="text-xl font-semibold">AI Chat</h2>
         <p className="mt-1 text-sm text-slate-600">
-          Powers /chat. Anthropic Claude is the only provider implemented today;
-          OpenAI and Ollama are planned.
+          Powers /chat. Anthropic and OpenAI both work; pick one as the active
+          provider. Keys live in the OS keychain.
         </p>
-        <div className="mt-4 space-y-3">
-          <div className="rounded border bg-slate-50 p-2 text-xs">
-            <div>
-              <strong>Anthropic:</strong>{" "}
-              {anthropic?.configured ? (
-                <span className="text-emerald-700">configured ({anthropic.model ?? "model unknown"})</span>
-              ) : (
-                <span className="text-amber-700">not configured</span>
-              )}
-            </div>
-          </div>
-          <label className="block">
-            <span className="text-sm text-slate-700">Anthropic API Key</span>
-            <input
-              type="password"
-              className="mt-1 w-full rounded border px-2 py-1 font-mono text-xs"
-              value={anthropicKey}
-              onChange={(e) => setAnthropicKey(e.target.value)}
-              placeholder="sk-ant-..."
-              autoComplete="off"
-            />
-          </label>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              disabled={busy || !anthropicKey.trim()}
-              onClick={onSaveAnthropic}
-              className="rounded bg-slate-800 px-3 py-1 text-sm text-white disabled:opacity-50"
-            >
-              Save key
-            </button>
-            <button
-              type="button"
-              disabled={busy || !anthropic?.configured}
-              onClick={onClearAnthropic}
-              className="rounded border px-3 py-1 text-sm disabled:opacity-50"
-            >
-              Remove
-            </button>
-          </div>
+
+        <div className="mt-4 space-y-4">
+          {PROVIDERS.map((p) => {
+            const status = aiStatus.find((s) => s.provider === p.id);
+            const isActive = activeProvider === p.id;
+            const draft = keyDrafts[p.id] ?? "";
+            return (
+              <div key={p.id} className="rounded border p-3">
+                <div className="flex items-center justify-between text-sm">
+                  <div>
+                    <strong>{p.label}</strong>
+                    <div className="text-xs text-slate-500">
+                      {status?.configured ? (
+                        isActive ? (
+                          <span className="text-emerald-700">
+                            active ({status.model ?? "model unknown"})
+                          </span>
+                        ) : (
+                          <span className="text-slate-600">stored, inactive</span>
+                        )
+                      ) : (
+                        <span className="text-amber-700">no key stored</span>
+                      )}
+                    </div>
+                  </div>
+                  {status?.configured && !isActive && (
+                    <button
+                      type="button"
+                      onClick={() => onActivate(p.id)}
+                      disabled={busy}
+                      className="rounded border px-2 py-0.5 text-xs disabled:opacity-50"
+                    >
+                      Activate
+                    </button>
+                  )}
+                </div>
+                <label className="mt-2 block">
+                  <span className="text-xs text-slate-600">API Key</span>
+                  <input
+                    type="password"
+                    className="mt-1 w-full rounded border px-2 py-1 font-mono text-xs"
+                    value={draft}
+                    onChange={(e) =>
+                      setKeyDrafts((d) => ({ ...d, [p.id]: e.target.value }))
+                    }
+                    placeholder={p.placeholder}
+                    autoComplete="off"
+                  />
+                </label>
+                <div className="mt-2 flex gap-2">
+                  <button
+                    type="button"
+                    disabled={busy || !draft.trim()}
+                    onClick={() => onSaveAi(p.id)}
+                    className="rounded bg-slate-800 px-3 py-1 text-xs text-white disabled:opacity-50"
+                  >
+                    Save key
+                  </button>
+                  <button
+                    type="button"
+                    disabled={busy || !status?.configured}
+                    onClick={() => onClearAi(p.id)}
+                    className="rounded border px-3 py-1 text-xs disabled:opacity-50"
+                  >
+                    Remove
+                  </button>
+                </div>
+              </div>
+            );
+          })}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

Closes the last item from the vecdoor plan — AI provider expansion. OpenAI lands as a second AiClient implementation alongside Anthropic. Stacked on PR #32.

The AiClient trait is the only seam the rest of the app talks to, so most of the diff is additive.

## What works after this PR

- /settings AI Chat section now lists both providers. Each row shows storage state + active marker, with an Activate button when the key is stored but not active. Key drafts are kept per-provider so the user can paste both at once.
- Both keys stored simultaneously is fine. The user picks which one is active via Activate; switching is instant, no re-keying.
- /chat works against either provider transparently — same Quick Actions, same attachment UX.
- /usage AI Chat tab already groups by provider/model so spend across the two providers is visible side by side.

## Backend changes (src-tauri/)

- ai::openai::OpenAiClient — /v1/chat/completions client. System prompt prepended to the message list (vs Anthropic's separate top-level field). Pricing table covers gpt-4o, gpt-4o-mini, gpt-4.1 family, o4-mini; unknown models fall back to gpt-4o rates with a tracing::warn.
- commands::ai:
  - new ai_set_active_provider command for flipping providers without re-keying.
  - PROVIDERS constant + build_client() helper so save / clear / set_active share validation.
  - ai_provider_status returns one row per known provider with configured + (when active) model populated.
  - ai_clear_provider_key now only drops the active client when the cleared provider is the active one — removing an inactive key doesn't kick the user out of the running chat.
- state::AppState restores the active provider on startup with a preference order: Anthropic wins if both are stored, otherwise OpenAI, otherwise none.

## Frontend changes (src/)

- SettingsPage rewritten as a provider list driven by a small PROVIDERS array — adding Ollama later is an array-entry change.
- lib/tauri.ts gains the aiSetActiveProvider wrapper.

## Out of scope, deferred

- Ollama (local-first / offline-capable) — separate PR; needs a base-URL field on top of the API-key flow and a different "configured" check (model present in the local Ollama install rather than a key in the keychain).
- Model picker per provider (right now both default to gpt-4o-mini / claude-sonnet-4-6). Easy follow-up once users start asking for a specific model.

## Test plan
- [ ] cd apps/dataforseo-app/src-tauri && cargo check.
- [ ] tauri:dev: paste both an Anthropic and OpenAI key in /settings. Confirm Activate buttons toggle the active provider; chat_send works against each in turn.
- [ ] Remove the inactive key and confirm the active session stays intact.
- [ ] /usage AI Chat tab: run a chat against each provider, confirm the by-model bar chart shows two distinct rows.


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_