### PR TITLE
FEAT: Markdown rendering and thread export in chat

### DIFF
--- a/apps/dataforseo-app/package.json
+++ b/apps/dataforseo-app/package.json
@@ -20,8 +20,11 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.4.1",
+    "react-markdown": "^9.0.1",
     "react-router-dom": "^6.28.0",
-    "recharts": "^2.13.3"
+    "recharts": "^2.13.3",
+    "rehype-sanitize": "^6.0.0",
+    "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.1.0",

--- a/apps/dataforseo-app/package.json
+++ b/apps/dataforseo-app/package.json
@@ -27,6 +27,7 @@
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.15",
     "@tauri-apps/cli": "^2.1.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",

--- a/apps/dataforseo-app/src/components/MarkdownView.tsx
+++ b/apps/dataforseo-app/src/components/MarkdownView.tsx
@@ -1,11 +1,22 @@
 import ReactMarkdown from "react-markdown";
-import rehypeSanitize from "rehype-sanitize";
+import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 
 interface Props {
   content: string;
   className?: string;
 }
+
+/// Sanitize schema with target+rel explicitly whitelisted. Default schema
+/// strips them on <a> elements, which would defeat our open-in-system-browser
+/// behaviour for the Tauri webview.
+const SCHEMA = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    a: [...(defaultSchema.attributes?.a ?? []), "target", "rel"],
+  },
+};
 
 /// Markdown renderer for assistant chat messages (and anywhere else we want
 /// to render LLM output safely). GFM gives us tables + strikethrough; sanitize
@@ -17,9 +28,11 @@ export default function MarkdownView({ content, className }: Props) {
     >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeSanitize]}
+        rehypePlugins={[[rehypeSanitize, SCHEMA]]}
         components={{
-          a: ({ href, children, ...props }) => (
+          // Destructure `node` (react-markdown v9 injects it) so it doesn't
+          // land on the DOM element and trip React's invalid-attribute warning.
+          a: ({ node: _node, href, children, ...props }) => (
             <a
               href={href}
               target="_blank"
@@ -30,13 +43,14 @@ export default function MarkdownView({ content, className }: Props) {
               {children}
             </a>
           ),
-          // Inline code shouldn't get the prose-pre treatment; differentiate
-          // by checking for the `inline` flag react-markdown injects.
-          code: ({ children, className, ...props }) => {
-            const isBlock = (className ?? "").startsWith("language-");
+          code: ({ node: _node, children, className: codeClass, ...props }) => {
+            // Inline code shouldn't get the prose-pre treatment; differentiate
+            // by checking for the `language-*` class react-markdown injects on
+            // fenced blocks.
+            const isBlock = (codeClass ?? "").startsWith("language-");
             if (isBlock) {
               return (
-                <code className={className} {...props}>
+                <code className={codeClass} {...props}>
                   {children}
                 </code>
               );

--- a/apps/dataforseo-app/src/components/MarkdownView.tsx
+++ b/apps/dataforseo-app/src/components/MarkdownView.tsx
@@ -1,0 +1,59 @@
+import ReactMarkdown from "react-markdown";
+import rehypeSanitize from "rehype-sanitize";
+import remarkGfm from "remark-gfm";
+
+interface Props {
+  content: string;
+  className?: string;
+}
+
+/// Markdown renderer for assistant chat messages (and anywhere else we want
+/// to render LLM output safely). GFM gives us tables + strikethrough; sanitize
+/// strips raw HTML so model output can't inject scripts or break the layout.
+export default function MarkdownView({ content, className }: Props) {
+  return (
+    <div
+      className={`prose prose-sm max-w-none prose-pre:bg-slate-900 prose-pre:text-slate-100 ${className ?? ""}`}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeSanitize]}
+        components={{
+          a: ({ href, children, ...props }) => (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 hover:underline"
+              {...props}
+            >
+              {children}
+            </a>
+          ),
+          // Inline code shouldn't get the prose-pre treatment; differentiate
+          // by checking for the `inline` flag react-markdown injects.
+          code: ({ children, className, ...props }) => {
+            const isBlock = (className ?? "").startsWith("language-");
+            if (isBlock) {
+              return (
+                <code className={className} {...props}>
+                  {children}
+                </code>
+              );
+            }
+            return (
+              <code
+                className="rounded bg-slate-100 px-1 py-0.5 text-xs font-mono"
+                {...props}
+              >
+                {children}
+              </code>
+            );
+          },
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/apps/dataforseo-app/src/lib/export.ts
+++ b/apps/dataforseo-app/src/lib/export.ts
@@ -80,10 +80,14 @@ export function downloadJson<T>(rows: T[], filename: string): void {
   triggerBlobDownload(JSON.stringify(rows, null, 2), filename, "application/json");
 }
 
+export function downloadMarkdown(content: string, filename: string): void {
+  triggerBlobDownload(content, filename, "text/markdown;charset=utf-8");
+}
+
 /// Stamp a filename with a sortable timestamp so users can collect repeat
 /// exports without overwriting. Sanitises the stem so it cannot blow up on
 /// Windows: drops any of <>:"/\|?* and collapses runs of whitespace.
-export function timestampedFilename(stem: string, ext: "csv" | "json"): string {
+export function timestampedFilename(stem: string, ext: "csv" | "json" | "md"): string {
   const safe = stem.replace(/[<>:"/\\|?*\s]+/g, "-").replace(/^-+|-+$/g, "") || "export";
   const now = new Date();
   const pad = (n: number) => n.toString().padStart(2, "0");

--- a/apps/dataforseo-app/src/routes/ChatPage.tsx
+++ b/apps/dataforseo-app/src/routes/ChatPage.tsx
@@ -298,7 +298,7 @@ function threadToMarkdown(session: ChatSession, messages: StoredChatMessage[]): 
     if (m.cost_usd != null) {
       lines.push("");
       lines.push(
-        `*${m.input_tokens ?? 0}+${m.output_tokens ?? 0} tok · ${m.cost_usd.toFixed(4)} USD*`,
+        `*${m.input_tokens ?? 0}+${m.output_tokens ?? 0} tok · ${formatUsd(m.cost_usd)}*`,
       );
     }
     lines.push("");

--- a/apps/dataforseo-app/src/routes/ChatPage.tsx
+++ b/apps/dataforseo-app/src/routes/ChatPage.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
+import MarkdownView from "../components/MarkdownView";
+import { downloadJson, downloadMarkdown, timestampedFilename } from "../lib/export";
 import { formatUsd } from "../lib/format";
 import {
   tauriApi,
@@ -167,7 +169,7 @@ export default function ChatPage() {
           )}
           {activeSession && (
             <>
-              <SessionHeader session={activeSession} />
+              <SessionHeader session={activeSession} messages={messages} />
               <ChatThread threadRef={threadRef} messages={messages} busy={busy} />
               <ChatInput
                 templates={templates}
@@ -226,19 +228,82 @@ function SessionsSidebar({
   );
 }
 
-function SessionHeader({ session }: { session: ChatSession }) {
+function SessionHeader({
+  session,
+  messages,
+}: {
+  session: ChatSession;
+  messages: StoredChatMessage[];
+}) {
+  function exportMarkdown() {
+    const stem = `chat-${session.title ?? session.id}`;
+    downloadMarkdown(threadToMarkdown(session, messages), timestampedFilename(stem, "md"));
+  }
+  function exportJson() {
+    const stem = `chat-${session.title ?? session.id}`;
+    downloadJson(messages, timestampedFilename(stem, "json"));
+  }
   return (
-    <div className="rounded border bg-slate-50 p-2 text-xs text-slate-600">
-      {session.attachment_summary && (
-        <div>
-          📎 <strong>Attached:</strong> {session.attachment_summary}
-        </div>
-      )}
+    <div className="flex items-start justify-between rounded border bg-slate-50 p-2 text-xs text-slate-600">
       <div>
-        {session.provider} · {session.model}
+        {session.attachment_summary && (
+          <div>
+            📎 <strong>Attached:</strong> {session.attachment_summary}
+          </div>
+        )}
+        <div>
+          {session.provider} · {session.model}
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={exportMarkdown}
+          disabled={messages.length === 0}
+          className="rounded border bg-white px-2 py-0.5 text-xs disabled:opacity-50"
+          title="Download the thread as a Markdown file"
+        >
+          Export .md
+        </button>
+        <button
+          type="button"
+          onClick={exportJson}
+          disabled={messages.length === 0}
+          className="rounded border bg-white px-2 py-0.5 text-xs disabled:opacity-50"
+          title="Download the raw message history as JSON"
+        >
+          .json
+        </button>
       </div>
     </div>
   );
+}
+
+function threadToMarkdown(session: ChatSession, messages: StoredChatMessage[]): string {
+  const lines: string[] = [];
+  lines.push(`# Chat — ${session.title ?? `session ${session.id}`}`);
+  lines.push(`*${session.provider} · ${session.model}*`);
+  if (session.attachment_summary) {
+    lines.push(`*Attached:* ${session.attachment_summary}`);
+  }
+  lines.push("");
+  for (const m of messages) {
+    if (m.role === "system") continue; // system isn't a turn the user authored
+    const heading = m.role === "user" ? "**You**" : "**Assistant**";
+    lines.push(`---`);
+    lines.push("");
+    lines.push(heading);
+    lines.push("");
+    lines.push(m.content);
+    if (m.cost_usd != null) {
+      lines.push("");
+      lines.push(
+        `*${m.input_tokens ?? 0}+${m.output_tokens ?? 0} tok · ${m.cost_usd.toFixed(4)} USD*`,
+      );
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
 }
 
 // `ref` is reserved on functional components in React 18 unless wrapped in
@@ -266,18 +331,26 @@ const ChatThread = ({
 
 function MessageBubble({ message }: { message: StoredChatMessage }) {
   const isUser = message.role === "user";
+  const isAssistant = message.role === "assistant";
   return (
     <div className={`flex ${isUser ? "justify-end" : "justify-start"}`}>
       <div
-        className={`max-w-[85%] rounded px-3 py-2 text-sm whitespace-pre-wrap ${
+        className={`max-w-[85%] rounded px-3 py-2 text-sm ${
           isUser
-            ? "bg-slate-800 text-white"
-            : message.role === "assistant"
+            ? "bg-slate-800 text-white whitespace-pre-wrap"
+            : isAssistant
               ? "bg-slate-100 text-slate-900"
-              : "bg-amber-50 text-amber-900 text-xs"
+              : "bg-amber-50 text-amber-900 text-xs whitespace-pre-wrap"
         }`}
       >
-        {message.content}
+        {/* Render assistant turns as Markdown — headings, lists, code, tables.
+            User turns stay plain so a stray ** doesn't render as bold against
+            the user's intent. */}
+        {isAssistant ? (
+          <MarkdownView content={message.content} />
+        ) : (
+          message.content
+        )}
         {message.cost_usd != null && (
           <div className="mt-1 text-[10px] opacity-60">
             {message.input_tokens}+{message.output_tokens} tok · {formatUsd(message.cost_usd)}

--- a/apps/dataforseo-app/tailwind.config.ts
+++ b/apps/dataforseo-app/tailwind.config.ts
@@ -1,7 +1,8 @@
 import type { Config } from "tailwindcss";
+import typography from "@tailwindcss/typography";
 
 export default {
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
   theme: { extend: {} },
-  plugins: [],
+  plugins: [typography],
 } satisfies Config;


### PR DESCRIPTION
## Summary

Two deferred items from the PR #29 out-of-scope list, both real polish gaps in the chat module — the headline vecdoor feature.

Found by auditing the Chat code: the chat bubble was using `whitespace-pre-wrap` so assistant output like `**bold**`, `# heading`, fenced code blocks rendered as literal source. All four built-in Quick Actions (Cluster, Blog Ideas, Intent, Titles) generate markdown, so the user was reading raw markup.

Stacked on PR #33.

## What changes

### 1. Markdown rendering for assistant messages

- New `components/MarkdownView.tsx` wraps `react-markdown` with `remark-gfm` (tables, strikethrough) and `rehype-sanitize` (strips raw HTML — no script execution from model output).
- Inline code gets a light pill style; code blocks get the dark `prose-pre` treatment.
- Links open in the system browser via `target=_blank`.
- Only assistant turns are rendered as markdown — user turns stay plain so a stray `**` in a question doesnt render as bold against the users intent.

### 2. Thread export

- `SessionHeader` gains Export `.md` and `.json` buttons.
- Markdown export produces a clean transcript: H1 with the session title, role headings, separator rules between turns, per-assistant-turn token + cost footers.
- JSON export is the raw `StoredChatMessage[]` array for re-import into a future "import session" feature.
- `lib/export.ts` already had the blob-download plumbing — extended `timestampedFilename` with `md` support and added `downloadMarkdown`.

## Dependencies

`package.json` gains:
- `react-markdown` ^9 (~30KB gzipped)
- `remark-gfm` ^4 (GFM extensions)
- `rehype-sanitize` ^6 (XSS guard)

## Out of scope

- Streaming responses (Anthropic SSE / OpenAI streaming) — separate PR; meaningful improvement once chats grow longer than a few sentences.
- Markdown rendering in user bubbles (current behaviour: pre-wrap so the user sees exactly what they typed). If users start composing markdown in their prompts, easy follow-up.

## Test plan
- [ ] cd apps/dataforseo-app && npm install (pulls the three new deps).
- [ ] tauri:dev, attach a keyword table, run the Cluster Quick Action. Confirm the assistants response renders with proper headings and lists.
- [ ] Click Export .md, open in a markdown previewer, confirm the transcript is well-formed (separators between turns, cost footers).
- [ ] Click .json, confirm the file parses back to a valid `StoredChatMessage[]`.
- [ ] Send a prompt containing literal Markdown (e.g., `**bold**`) — confirm it shows as text in the user bubble, NOT rendered.


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_