### PR TITLE
feat(dataforseo-app): Backlinks Phase 2 milestone 2 — detail endpoint + filter DSL

### DIFF
--- a/apps/dataforseo-app/src-tauri/src/api/backlinks.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/backlinks.rs
@@ -2,12 +2,21 @@
 //! `summary/live` endpoint — returns dashboard-ready aggregates per target
 //! domain (total backlinks, referring domains, dofollow split, TLD/anchor
 //! distributions) for a single 0.02 USD request.
+//!
+//! `backlinks_live` (the per-link detail endpoint) is the next step up: same
+//! shape as Ahrefs / SEMrush "Backlinks" table — one row per link, with
+//! anchor, source URL, target URL, dofollow flag, and rank metrics. The
+//! optional `Filter` argument is the recursive DSL from `domain::filters`,
+//! so the UI can compose the typical "dofollow only", "lost links",
+//! "rank > 30 AND anchor like %seo%" presets without bespoke serializer
+//! code.
 
 use serde::Deserialize;
 use serde_json::Value;
 
 use crate::api::client::ApiClient;
 use crate::api::ensure_api_success;
+use crate::domain::filters::Filter;
 use crate::errors::{AppError, Result};
 use crate::ratelimit::Family;
 
@@ -65,4 +74,103 @@ impl ApiClient {
 
         Ok(BacklinksSummaryResponse { summary, cost })
     }
+
+    /// Per-link detail. `mode` is one of "as_is" / "one_per_domain" /
+    /// "one_per_anchor" — DataForSEO's deduplication knob. `limit` is
+    /// capped at 1000 per request by the API; the caller is responsible
+    /// for pagination if it wants more.
+    pub async fn backlinks_live(
+        &self,
+        args: BacklinksDetailArgs<'_>,
+    ) -> Result<BacklinksDetailResponse> {
+        let mut payload = serde_json::json!({
+            "target": args.target,
+            "mode": args.mode,
+            "limit": args.limit,
+            "offset": args.offset,
+            "include_subdomains": args.include_subdomains,
+            "backlinks_status_type": args.backlinks_status_type,
+        });
+        if let Some(filter) = args.filter {
+            // DataForSEO's /backlinks/live takes the filter as an array,
+            // even for a single condition. The DSL's `to_wire()` returns
+            // a 3-elem array for a Condition leaf, so wrap that case so
+            // the API sees `[[field, op, value]]`.
+            let wire = filter.to_wire();
+            let filters = if wire
+                .as_array()
+                .and_then(|a| a.first())
+                .map(|v| !v.is_array())
+                .unwrap_or(true)
+            {
+                serde_json::json!([wire])
+            } else {
+                wire
+            };
+            payload["filters"] = filters;
+        }
+        if let Some(order) = args.order_by {
+            payload["order_by"] = serde_json::json!(order);
+        }
+
+        let body = serde_json::json!([payload]);
+        let raw = self
+            .post_json(Family::Backlinks, "/v3/backlinks/backlinks/live", &body)
+            .await?;
+        let cost = ensure_api_success(&raw)?;
+
+        let result = raw
+            .pointer("/tasks/0/result/0")
+            .ok_or_else(|| AppError::Parse("backlinks detail missing tasks[0].result[0]".into()))?;
+
+        let total_count = result
+            .pointer("/total_count")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        let items_count = result
+            .pointer("/items_count")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        let items = result
+            .pointer("/items")
+            .cloned()
+            .unwrap_or(Value::Array(Vec::new()));
+
+        Ok(BacklinksDetailResponse {
+            target: args.target.to_string(),
+            total_count,
+            items_count,
+            items,
+            cost,
+        })
+    }
+}
+
+/// Inputs for `backlinks_live`. Only `target` is required; the rest mirror
+/// the DataForSEO defaults so callers can pass `Default::default()` and
+/// adjust just the fields they care about.
+#[derive(Debug, Clone)]
+pub struct BacklinksDetailArgs<'a> {
+    pub target: &'a str,
+    pub mode: &'static str,
+    pub limit: u32,
+    pub offset: u32,
+    pub include_subdomains: bool,
+    /// "all" | "live" | "lost". Mirrors DataForSEO's `backlinks_status_type`.
+    pub backlinks_status_type: &'static str,
+    pub filter: Option<&'a Filter>,
+    /// e.g. ["domain_from_rank,desc"] — DataForSEO accepts an array of
+    /// "field,direction" strings.
+    pub order_by: Option<Vec<String>>,
+}
+
+#[derive(Debug)]
+pub struct BacklinksDetailResponse {
+    pub target: String,
+    pub total_count: i64,
+    pub items_count: i64,
+    /// Raw items array preserved verbatim — the UI renders columns it
+    /// recognises and lets the user expand the rest.
+    pub items: Value,
+    pub cost: f64,
 }

--- a/apps/dataforseo-app/src-tauri/src/api/backlinks.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/backlinks.rs
@@ -94,20 +94,32 @@ impl ApiClient {
         if let Some(filter) = args.filter {
             // DataForSEO's /backlinks/live takes the filter as an array,
             // even for a single condition. The DSL's `to_wire()` returns
-            // a 3-elem array for a Condition leaf, so wrap that case so
-            // the API sees `[[field, op, value]]`.
+            // a 3-elem array for a Condition leaf — its first element is
+            // the field name (string), which is the most reliable leaf
+            // marker. A Group's wire form starts with another array, so
+            // it's already in the outer-array shape DataForSEO expects.
+            //
+            // Only attach `filters` if there's actually something to send;
+            // an empty Group would otherwise produce `[[]]`, which the API
+            // rejects.
             let wire = filter.to_wire();
-            let filters = if wire
+            let is_leaf = wire
                 .as_array()
                 .and_then(|a| a.first())
-                .map(|v| !v.is_array())
-                .unwrap_or(true)
-            {
+                .map(|v| v.is_string())
+                .unwrap_or(false);
+            let filters = if is_leaf {
                 serde_json::json!([wire])
             } else {
                 wire
             };
-            payload["filters"] = filters;
+            if filters
+                .as_array()
+                .map(|a| !a.is_empty())
+                .unwrap_or(false)
+            {
+                payload["filters"] = filters;
+            }
         }
         if let Some(order) = args.order_by {
             payload["order_by"] = serde_json::json!(order);

--- a/apps/dataforseo-app/src-tauri/src/api/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod backlinks;
 pub mod client;
 pub mod keywords_data;
 pub mod labs;

--- a/apps/dataforseo-app/src-tauri/src/commands/backlinks.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/backlinks.rs
@@ -1,13 +1,15 @@
 use chrono::Duration;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::State;
 use tokio::task;
 use ts_rs::TS;
 
+use crate::api::backlinks::BacklinksDetailArgs;
 use crate::commands::ledger::run_with_ledger;
 use crate::domain::cost::{self, CostAction};
 use crate::domain::endpoints;
+use crate::domain::filters::Filter;
 use crate::domain::types::Mode;
 use crate::errors::{AppError, Result};
 use crate::state::AppState;
@@ -103,5 +105,115 @@ pub async fn backlinks_summary(
         estimated_usd,
         from_cache: false,
         fetched_at: None,
+    })
+}
+
+/// Inputs for `backlinks_detail`. The frontend builds this; the Rust side
+/// validates and clamps. `mode` and `backlinks_status_type` are stringly
+/// typed to match DataForSEO; we narrow them here so a typo doesn't reach
+/// the API.
+#[derive(Debug, Clone, Deserialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+#[serde(rename_all = "camelCase")]
+pub struct BacklinksDetailParams {
+    pub target: String,
+    /// "as_is" | "one_per_domain" | "one_per_anchor"
+    pub mode: String,
+    /// "all" | "live" | "lost"
+    pub status: String,
+    pub limit: u32,
+    pub offset: u32,
+    pub include_subdomains: bool,
+    /// Optional filter tree from the visual builder / preset dropdown.
+    pub filter: Option<Filter>,
+    /// e.g. ["domain_from_rank,desc"] — passed through verbatim.
+    pub order_by: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct BacklinksDetailView {
+    pub target: String,
+    pub total_count: i64,
+    pub items_count: i64,
+    pub items: Value,
+    pub cost_usd: f64,
+    pub estimated_usd: f64,
+}
+
+const DETAIL_MAX_LIMIT: u32 = 1000;
+
+#[tauri::command]
+#[tracing::instrument(skip(state, params))]
+pub async fn backlinks_detail(
+    state: State<'_, AppState>,
+    params: BacklinksDetailParams,
+) -> Result<BacklinksDetailView> {
+    let target = params.target.trim().to_owned();
+    if target.is_empty() {
+        return Err(AppError::Validation("target required".into()));
+    }
+    let mode = match params.mode.as_str() {
+        "as_is" => "as_is",
+        "one_per_domain" => "one_per_domain",
+        "one_per_anchor" => "one_per_anchor",
+        other => {
+            return Err(AppError::Validation(format!(
+                "invalid mode {other:?}; expected as_is|one_per_domain|one_per_anchor"
+            )))
+        }
+    };
+    let status = match params.status.as_str() {
+        "all" => "all",
+        "live" => "live",
+        "lost" => "lost",
+        other => {
+            return Err(AppError::Validation(format!(
+                "invalid status {other:?}; expected all|live|lost"
+            )))
+        }
+    };
+    let limit = params.limit.clamp(1, DETAIL_MAX_LIMIT);
+
+    let estimated_usd = cost::estimate(&CostAction::Backlinks {
+        target_count: 1,
+        rows_per_target: limit,
+    });
+
+    let api = state.api.clone();
+    let filter = params.filter.clone();
+    let order_by = params.order_by.clone();
+    let target_for_call = target.clone();
+    let resp = run_with_ledger(
+        state.store.clone(),
+        endpoints::BACKLINKS_DETAIL,
+        Mode::Live,
+        estimated_usd,
+        limit as i64,
+        move || async move {
+            let args = BacklinksDetailArgs {
+                target: &target_for_call,
+                mode,
+                limit,
+                offset: params.offset,
+                include_subdomains: params.include_subdomains,
+                backlinks_status_type: status,
+                filter: filter.as_ref(),
+                order_by,
+            };
+            let r = api.backlinks_live(args).await?;
+            let cost = r.cost;
+            Ok((r, cost))
+        },
+    )
+    .await?;
+
+    Ok(BacklinksDetailView {
+        target: resp.target,
+        total_count: resp.total_count,
+        items_count: resp.items_count,
+        items: resp.items,
+        cost_usd: resp.cost,
+        estimated_usd,
     })
 }

--- a/apps/dataforseo-app/src-tauri/src/domain/filters.rs
+++ b/apps/dataforseo-app/src-tauri/src/domain/filters.rs
@@ -105,7 +105,13 @@ impl Filter {
                 let mut out = Vec::with_capacity(nodes.len() * 2 - 1);
                 for (i, node) in nodes.iter().enumerate() {
                     out.push(node.to_wire());
-                    if let Some(conn) = connectors.get(i) {
+                    // Always emit a connector between nodes — defaulting to
+                    // And if `connectors` is shorter than `nodes.len() - 1`.
+                    // Without this, a malformed Group with too few connectors
+                    // would serialize as `[cond1, cond2]`, which DataForSEO
+                    // rejects as invalid filter syntax.
+                    if i < nodes.len() - 1 {
+                        let conn = connectors.get(i).unwrap_or(&Logical::And);
                         out.push(json!(match conn {
                             Logical::And => "and",
                             Logical::Or => "or",
@@ -228,5 +234,35 @@ mod tests {
     fn empty_group_serializes_to_empty_array() {
         let f = Filter::Group { nodes: vec![], connectors: vec![] };
         assert_eq!(f.to_wire(), json!([]));
+    }
+
+    #[test]
+    fn missing_connector_defaults_to_and() {
+        // Malformed group with two nodes but no connectors. We default to
+        // "and" so the wire form is still valid filter syntax instead of
+        // `[cond1, cond2]` (which DataForSEO rejects).
+        let f = Filter::Group {
+            nodes: vec![
+                Filter::Condition {
+                    field: "dofollow".into(),
+                    operator: Operator::Eq,
+                    value: json!(true),
+                },
+                Filter::Condition {
+                    field: "rank".into(),
+                    operator: Operator::Gt,
+                    value: json!(30),
+                },
+            ],
+            connectors: vec![],
+        };
+        assert_eq!(
+            f.to_wire(),
+            json!([
+                ["dofollow", "=", true],
+                "and",
+                ["rank", ">", 30]
+            ])
+        );
     }
 }

--- a/apps/dataforseo-app/src-tauri/src/domain/filters.rs
+++ b/apps/dataforseo-app/src-tauri/src/domain/filters.rs
@@ -1,0 +1,232 @@
+//! Generic filter DSL for DataForSEO endpoints that accept `filters[]`.
+//!
+//! Source: docs/DATAFORSEO_BACKLINKS_PHASE2.md Teil 3. The DSL is a recursive
+//! tree: a leaf is a (field, operator, value) triple; a composite alternates
+//! filter trees with logical "and" / "or" connectors. The on-the-wire shape
+//! matches DataForSEO exactly so the visual filter-builder UI can build a
+//! `Filter` value, hand it to the Rust backend, and have it serialised
+//! correctly without further translation.
+//!
+//! Examples:
+//!
+//! - `[["dofollow", "=", true]]`
+//! - `[["dofollow", "=", true], "and", [["anchor", "ilike", "%seo%"], "or",
+//!    ["anchor", "ilike", "%marketing%"]]]`
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use ts_rs::TS;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+#[serde(rename_all = "snake_case")]
+pub enum Operator {
+    Eq,
+    Ne,
+    Gt,
+    Lt,
+    Ge,
+    Le,
+    In,
+    NotIn,
+    Like,
+    NotLike,
+    Ilike,
+    NotIlike,
+    Match,
+    NotMatch,
+}
+
+impl Operator {
+    /// Serialised exactly as DataForSEO accepts.
+    pub fn as_wire(self) -> &'static str {
+        match self {
+            Operator::Eq => "=",
+            Operator::Ne => "<>",
+            Operator::Gt => ">",
+            Operator::Lt => "<",
+            Operator::Ge => ">=",
+            Operator::Le => "<=",
+            Operator::In => "in",
+            Operator::NotIn => "not_in",
+            Operator::Like => "like",
+            Operator::NotLike => "not_like",
+            Operator::Ilike => "ilike",
+            Operator::NotIlike => "not_ilike",
+            Operator::Match => "match",
+            Operator::NotMatch => "not_match",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+#[serde(rename_all = "lowercase")]
+pub enum Logical {
+    And,
+    Or,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Filter {
+    /// Leaf condition: field operator value.
+    Condition {
+        field: String,
+        operator: Operator,
+        value: serde_json::Value,
+    },
+    /// Composite: alternating filter | logical | filter | logical | filter ...
+    Group {
+        /// Always 1, 3, 5, ... children.
+        nodes: Vec<Filter>,
+        /// Always nodes.len() - 1 connectors.
+        connectors: Vec<Logical>,
+    },
+}
+
+impl Filter {
+    /// Convert to DataForSEO's wire format. Conditions become 3-element
+    /// arrays; groups become 5+-element arrays alternating filter and
+    /// connector strings.
+    pub fn to_wire(&self) -> Value {
+        match self {
+            Filter::Condition { field, operator, value } => {
+                json!([field, operator.as_wire(), value])
+            }
+            Filter::Group { nodes, connectors } => {
+                if nodes.is_empty() {
+                    return Value::Array(Vec::new());
+                }
+                if nodes.len() == 1 {
+                    return nodes[0].to_wire();
+                }
+                let mut out = Vec::with_capacity(nodes.len() * 2 - 1);
+                for (i, node) in nodes.iter().enumerate() {
+                    out.push(node.to_wire());
+                    if let Some(conn) = connectors.get(i) {
+                        out.push(json!(match conn {
+                            Logical::And => "and",
+                            Logical::Or => "or",
+                        }));
+                    }
+                }
+                Value::Array(out)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_condition_serializes_as_three_element_array() {
+        let f = Filter::Condition {
+            field: "dofollow".into(),
+            operator: Operator::Eq,
+            value: json!(true),
+        };
+        assert_eq!(f.to_wire(), json!(["dofollow", "=", true]));
+    }
+
+    #[test]
+    fn negation_operators_use_underscores() {
+        let f = Filter::Condition {
+            field: "anchor".into(),
+            operator: Operator::NotIlike,
+            value: json!("%spam%"),
+        };
+        assert_eq!(f.to_wire(), json!(["anchor", "not_ilike", "%spam%"]));
+    }
+
+    #[test]
+    fn and_group_alternates_conditions_and_connectors() {
+        let f = Filter::Group {
+            nodes: vec![
+                Filter::Condition {
+                    field: "dofollow".into(),
+                    operator: Operator::Eq,
+                    value: json!(true),
+                },
+                Filter::Condition {
+                    field: "domain_from_rank".into(),
+                    operator: Operator::Gt,
+                    value: json!(30),
+                },
+            ],
+            connectors: vec![Logical::And],
+        };
+        assert_eq!(
+            f.to_wire(),
+            json!([
+                ["dofollow", "=", true],
+                "and",
+                ["domain_from_rank", ">", 30]
+            ])
+        );
+    }
+
+    #[test]
+    fn nested_group_preserves_structure() {
+        // (dofollow=true) AND ((anchor ilike "%seo%") OR (anchor ilike "%marketing%"))
+        let f = Filter::Group {
+            nodes: vec![
+                Filter::Condition {
+                    field: "dofollow".into(),
+                    operator: Operator::Eq,
+                    value: json!(true),
+                },
+                Filter::Group {
+                    nodes: vec![
+                        Filter::Condition {
+                            field: "anchor".into(),
+                            operator: Operator::Ilike,
+                            value: json!("%seo%"),
+                        },
+                        Filter::Condition {
+                            field: "anchor".into(),
+                            operator: Operator::Ilike,
+                            value: json!("%marketing%"),
+                        },
+                    ],
+                    connectors: vec![Logical::Or],
+                },
+            ],
+            connectors: vec![Logical::And],
+        };
+        assert_eq!(
+            f.to_wire(),
+            json!([
+                ["dofollow", "=", true],
+                "and",
+                [
+                    ["anchor", "ilike", "%seo%"],
+                    "or",
+                    ["anchor", "ilike", "%marketing%"]
+                ]
+            ])
+        );
+    }
+
+    #[test]
+    fn single_node_group_is_unwrapped() {
+        let f = Filter::Group {
+            nodes: vec![Filter::Condition {
+                field: "is_lost".into(),
+                operator: Operator::Eq,
+                value: json!(false),
+            }],
+            connectors: vec![],
+        };
+        assert_eq!(f.to_wire(), json!(["is_lost", "=", false]));
+    }
+
+    #[test]
+    fn empty_group_serializes_to_empty_array() {
+        let f = Filter::Group { nodes: vec![], connectors: vec![] };
+        assert_eq!(f.to_wire(), json!([]));
+    }
+}

--- a/apps/dataforseo-app/src-tauri/src/domain/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/domain/mod.rs
@@ -1,3 +1,4 @@
 pub mod cost;
 pub mod endpoints;
+pub mod filters;
 pub mod types;

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -52,6 +52,7 @@ pub fn run() {
             commands::serp::serp_task_status,
             commands::serp::serp_task_recent_batches,
             commands::backlinks::backlinks_summary,
+            commands::backlinks::backlinks_detail,
             commands::ai::ai_provider_status,
             commands::ai::ai_save_provider_key,
             commands::ai::ai_clear_provider_key,

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -100,6 +100,9 @@ export const tauriApi = {
   backlinksSummary: (args: { target: string; useCache: boolean }) =>
     invoke<BacklinksSummaryView>("backlinks_summary", args),
 
+  backlinksDetail: (params: BacklinksDetailParams) =>
+    invoke<BacklinksDetailView>("backlinks_detail", { params }),
+
   getRecentCalls: (args: { limit: number }) =>
     invoke<CallLogRow[]>("get_recent_calls", args),
 
@@ -242,6 +245,60 @@ export interface BacklinksSummaryView {
   estimated_usd: number;
   from_cache: boolean;
   fetched_at: string | null;
+}
+
+export type BacklinksDetailMode = "as_is" | "one_per_domain" | "one_per_anchor";
+export type BacklinksDetailStatus = "all" | "live" | "lost";
+
+// Mirrors the recursive Filter enum in domain::filters. Mostly built by the
+// preset dropdown for now; the full visual builder is a future milestone.
+export type FilterTree =
+  | {
+      kind: "condition";
+      field: string;
+      operator: FilterOperator;
+      value: unknown;
+    }
+  | { kind: "group"; nodes: FilterTree[]; connectors: FilterLogical[] };
+
+export type FilterOperator =
+  | "eq"
+  | "ne"
+  | "gt"
+  | "lt"
+  | "ge"
+  | "le"
+  | "in"
+  | "not_in"
+  | "like"
+  | "not_like"
+  | "ilike"
+  | "not_ilike"
+  | "match"
+  | "not_match";
+
+export type FilterLogical = "and" | "or";
+
+export interface BacklinksDetailParams {
+  target: string;
+  mode: BacklinksDetailMode;
+  status: BacklinksDetailStatus;
+  limit: number;
+  offset: number;
+  includeSubdomains: boolean;
+  filter: FilterTree | null;
+  orderBy: string[] | null;
+}
+
+export interface BacklinksDetailView {
+  target: string;
+  total_count: number;
+  items_count: number;
+  // DataForSEO returns ~25 fields per row — we keep them as `unknown` and
+  // let the table component pick the columns it can render.
+  items: Array<Record<string, unknown>>;
+  cost_usd: number;
+  estimated_usd: number;
 }
 
 export interface TaskBatchId {

--- a/apps/dataforseo-app/src/routes/BacklinksPage.tsx
+++ b/apps/dataforseo-app/src/routes/BacklinksPage.tsx
@@ -361,9 +361,18 @@ function DetailTab() {
                 min={1}
                 max={1000}
                 value={limit}
+                // Allow intermediate values during typing — clamping here
+                // would jump 1→empty→0 to 1, blocking the user from
+                // editing digit-by-digit. We finalise on blur instead.
                 onChange={(e) => {
-                  const n = Number(e.target.value);
-                  setLimit(Number.isFinite(n) ? Math.max(1, Math.min(1000, n)) : 100);
+                  const n = e.target.valueAsNumber;
+                  setLimit(Number.isFinite(n) ? n : 0);
+                }}
+                onBlur={(e) => {
+                  const n = e.target.valueAsNumber;
+                  setLimit(
+                    Number.isFinite(n) ? Math.max(1, Math.min(1000, n)) : 100,
+                  );
                 }}
                 disabled={busy}
                 className="rounded border px-2 py-1 disabled:bg-slate-50"

--- a/apps/dataforseo-app/src/routes/BacklinksPage.tsx
+++ b/apps/dataforseo-app/src/routes/BacklinksPage.tsx
@@ -1,11 +1,78 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import CostPreview from "../components/CostPreview";
 import { formatCount, formatUsd } from "../lib/format";
-import { tauriApi, type BacklinksSummaryView } from "../lib/tauri";
+import {
+  tauriApi,
+  type BacklinksDetailMode,
+  type BacklinksDetailStatus,
+  type BacklinksDetailView,
+  type BacklinksSummaryView,
+  type FilterTree,
+} from "../lib/tauri";
+
+type Tab = "summary" | "detail";
 
 export default function BacklinksPage() {
+  const [tab, setTab] = useState<Tab>("summary");
+
+  return (
+    <section className="flex flex-col gap-6">
+      <header>
+        <h2 className="text-xl font-semibold">Backlinks</h2>
+        <p className="text-sm text-slate-600">
+          Aggregate backlink profile for any domain — total links, referring
+          domains, dofollow split, TLD distribution. The summary endpoint is
+          cheap (one request, ~0.02 USD) and cached for 24 hours, so checking
+          a domain you've looked at recently is free.
+        </p>
+        <p className="mt-1 text-xs text-amber-700">
+          Reminder: DataForSEO's Backlinks family has a 100 USD/month minimum
+          spend. The commitment can be used across all DataForSEO APIs but
+          must be consumed monthly. Plan accordingly before activating.
+        </p>
+      </header>
+
+      <nav className="flex gap-1 border-b text-sm">
+        <TabButton active={tab === "summary"} onClick={() => setTab("summary")}>
+          Summary
+        </TabButton>
+        <TabButton active={tab === "detail"} onClick={() => setTab("detail")}>
+          Detail
+        </TabButton>
+      </nav>
+
+      {tab === "summary" ? <SummaryTab /> : <DetailTab />}
+    </section>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`-mb-px border-b-2 px-3 py-2 ${
+        active
+          ? "border-slate-800 text-slate-900"
+          : "border-transparent text-slate-500 hover:text-slate-700"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function SummaryTab() {
   const [target, setTarget] = useState("");
   const [busy, setBusy] = useState(false);
   const [summary, setSummary] = useState<BacklinksSummaryView | null>(null);
@@ -33,22 +100,7 @@ export default function BacklinksPage() {
   }
 
   return (
-    <section className="flex flex-col gap-6">
-      <header>
-        <h2 className="text-xl font-semibold">Backlinks</h2>
-        <p className="text-sm text-slate-600">
-          Aggregate backlink profile for any domain — total links, referring
-          domains, dofollow split, TLD distribution. The summary endpoint is
-          cheap (one request, ~0.02 USD) and cached for 24 hours, so checking
-          a domain you've looked at recently is free.
-        </p>
-        <p className="mt-1 text-xs text-amber-700">
-          Reminder: DataForSEO's Backlinks family has a 100 USD/month minimum
-          spend. The commitment can be used across all DataForSEO APIs but
-          must be consumed monthly. Plan accordingly before activating.
-        </p>
-      </header>
-
+    <div className="flex flex-col gap-6">
       <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_320px]">
         <label className="flex flex-col gap-1 text-sm">
           <span className="font-medium text-slate-700">Target domain</span>
@@ -72,9 +124,7 @@ export default function BacklinksPage() {
             }}
             details={[
               "Single backlinks_summary request",
-              useCache
-                ? "Cache reused if last fetch <24h"
-                : "Cache disabled",
+              useCache ? "Cache reused if last fetch <24h" : "Cache disabled",
             ]}
             disabled={busy || !target.trim()}
           />
@@ -105,7 +155,7 @@ export default function BacklinksPage() {
           Enter a domain above and click Load summary.
         </div>
       )}
-    </section>
+    </div>
   );
 }
 
@@ -164,4 +214,291 @@ function SummaryView({ view }: { view: BacklinksSummaryView }) {
       </details>
     </div>
   );
+}
+
+// ---------- Detail tab ----------
+
+type FilterPreset = "all" | "dofollow" | "rank30" | "lost";
+
+const PRESET_LABELS: Record<FilterPreset, string> = {
+  all: "All backlinks",
+  dofollow: "Dofollow only",
+  rank30: "Domain rank > 30",
+  lost: "Lost links",
+};
+
+// Each preset returns the (filter, statusOverride) pair. Status is forced to
+// "lost" for the lost preset; the rest leave the user's status selection
+// untouched. Filter is null for "all".
+function buildPreset(
+  preset: FilterPreset,
+): { filter: FilterTree | null; statusOverride: BacklinksDetailStatus | null } {
+  switch (preset) {
+    case "all":
+      return { filter: null, statusOverride: null };
+    case "dofollow":
+      return {
+        filter: { kind: "condition", field: "dofollow", operator: "eq", value: true },
+        statusOverride: null,
+      };
+    case "rank30":
+      return {
+        filter: { kind: "condition", field: "domain_from_rank", operator: "gt", value: 30 },
+        statusOverride: null,
+      };
+    case "lost":
+      // For "lost" we don't need a filter expression — DataForSEO has a
+      // dedicated `backlinks_status_type=lost` query parameter.
+      return { filter: null, statusOverride: "lost" };
+  }
+}
+
+function DetailTab() {
+  const [target, setTarget] = useState("");
+  const [mode, setMode] = useState<BacklinksDetailMode>("as_is");
+  const [status, setStatus] = useState<BacklinksDetailStatus>("live");
+  const [preset, setPreset] = useState<FilterPreset>("all");
+  const [limit, setLimit] = useState(100);
+  const [includeSubdomains, setIncludeSubdomains] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [view, setView] = useState<BacklinksDetailView | null>(null);
+
+  const effective = useMemo(() => buildPreset(preset), [preset]);
+  const effectiveStatus = effective.statusOverride ?? status;
+
+  async function onRun() {
+    const trimmed = target.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    try {
+      const result = await tauriApi.backlinksDetail({
+        target: trimmed,
+        mode,
+        status: effectiveStatus,
+        limit,
+        offset: 0,
+        includeSubdomains,
+        filter: effective.filter,
+        orderBy: ["domain_from_rank,desc"],
+      });
+      setView(result);
+      toast.success(
+        `Loaded ${formatCount(result.items_count)} of ${formatCount(result.total_count)} links (${formatUsd(result.cost_usd)})`,
+      );
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_320px]">
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-slate-700">Target domain</span>
+            <input
+              type="text"
+              value={target}
+              onChange={(e) => setTarget(e.target.value)}
+              disabled={busy}
+              className="rounded border px-2 py-1 font-mono text-sm disabled:bg-slate-50"
+              placeholder="example.com"
+              spellCheck={false}
+              autoComplete="off"
+            />
+          </label>
+
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <label className="flex flex-col gap-1">
+              <span className="font-medium text-slate-700">Preset</span>
+              <select
+                value={preset}
+                onChange={(e) => setPreset(e.target.value as FilterPreset)}
+                disabled={busy}
+                className="rounded border px-2 py-1 disabled:bg-slate-50"
+              >
+                {(Object.keys(PRESET_LABELS) as FilterPreset[]).map((p) => (
+                  <option key={p} value={p}>
+                    {PRESET_LABELS[p]}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="font-medium text-slate-700">Mode</span>
+              <select
+                value={mode}
+                onChange={(e) => setMode(e.target.value as BacklinksDetailMode)}
+                disabled={busy}
+                className="rounded border px-2 py-1 disabled:bg-slate-50"
+              >
+                <option value="as_is">As-is (raw)</option>
+                <option value="one_per_domain">One per domain</option>
+                <option value="one_per_anchor">One per anchor</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="font-medium text-slate-700">Status</span>
+              <select
+                value={effectiveStatus}
+                onChange={(e) =>
+                  setStatus(e.target.value as BacklinksDetailStatus)
+                }
+                disabled={busy || effective.statusOverride !== null}
+                className="rounded border px-2 py-1 disabled:bg-slate-50"
+              >
+                <option value="live">Live</option>
+                <option value="lost">Lost</option>
+                <option value="all">All</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="font-medium text-slate-700">Limit</span>
+              <input
+                type="number"
+                min={1}
+                max={1000}
+                value={limit}
+                onChange={(e) => {
+                  const n = Number(e.target.value);
+                  setLimit(Number.isFinite(n) ? Math.max(1, Math.min(1000, n)) : 100);
+                }}
+                disabled={busy}
+                className="rounded border px-2 py-1 disabled:bg-slate-50"
+              />
+            </label>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <CostPreview
+            action={{
+              kind: "Backlinks",
+              target_count: 1,
+              rows_per_target: limit,
+            }}
+            details={[
+              `Up to ${formatCount(limit)} rows`,
+              `Preset: ${PRESET_LABELS[preset]}`,
+              `Status: ${effectiveStatus}`,
+            ]}
+            disabled={busy || !target.trim()}
+          />
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={includeSubdomains}
+              onChange={(e) => setIncludeSubdomains(e.target.checked)}
+              disabled={busy}
+            />
+            Include subdomains
+          </label>
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={busy || !target.trim()}
+            className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+          >
+            {busy ? "Loading…" : "Load backlinks"}
+          </button>
+        </div>
+      </div>
+
+      {view && <DetailTable view={view} />}
+
+      {!view && !busy && (
+        <div className="rounded border bg-white p-8 text-center text-sm text-slate-500">
+          Pick a domain and a preset, then load the per-link table.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DetailTable({ view }: { view: BacklinksDetailView }) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+        <strong className="font-mono text-slate-700">{view.target}</strong>
+        <span>
+          {formatCount(view.items_count)} of {formatCount(view.total_count)} rows
+        </span>
+        <span className="ml-auto">
+          actual {formatUsd(view.cost_usd)} · estimated{" "}
+          {formatUsd(view.estimated_usd)}
+        </span>
+      </div>
+
+      <div className="overflow-x-auto rounded border bg-white">
+        <table className="min-w-full text-xs">
+          <thead className="bg-slate-50 text-slate-600">
+            <tr>
+              <th className="px-2 py-1 text-left">Source</th>
+              <th className="px-2 py-1 text-left">Anchor</th>
+              <th className="px-2 py-1 text-left">Target</th>
+              <th className="px-2 py-1 text-right">Rank</th>
+              <th className="px-2 py-1 text-center">Type</th>
+              <th className="px-2 py-1 text-center">Dofollow</th>
+            </tr>
+          </thead>
+          <tbody>
+            {view.items.map((row, i) => {
+              const sourceUrl = str(row, "url_from");
+              const anchor = str(row, "anchor");
+              const targetUrl = str(row, "url_to");
+              const rank = num(row, "domain_from_rank") ?? num(row, "rank");
+              const itemType = str(row, "item_type");
+              const dofollow = bool(row, "dofollow");
+              return (
+                <tr key={i} className="border-t hover:bg-slate-50">
+                  <td className="max-w-xs truncate px-2 py-1 font-mono">
+                    {sourceUrl ?? "—"}
+                  </td>
+                  <td className="max-w-xs truncate px-2 py-1">{anchor ?? "—"}</td>
+                  <td className="max-w-xs truncate px-2 py-1 font-mono">
+                    {targetUrl ?? "—"}
+                  </td>
+                  <td className="px-2 py-1 text-right tabular-nums">
+                    {rank != null ? rank : "—"}
+                  </td>
+                  <td className="px-2 py-1 text-center text-slate-500">
+                    {itemType ?? "—"}
+                  </td>
+                  <td className="px-2 py-1 text-center">
+                    {dofollow == null ? "—" : dofollow ? "yes" : "no"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <details className="rounded border bg-slate-50 p-3 text-xs">
+        <summary className="cursor-pointer font-medium text-slate-700">
+          Raw response (debug)
+        </summary>
+        <pre className="mt-2 max-h-96 overflow-auto text-[11px]">
+          {JSON.stringify(view.items, null, 2)}
+        </pre>
+      </details>
+    </div>
+  );
+}
+
+function str(row: Record<string, unknown>, key: string): string | null {
+  const v = row[key];
+  return typeof v === "string" ? v : null;
+}
+
+function num(row: Record<string, unknown>, key: string): number | null {
+  const v = row[key];
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function bool(row: Record<string, unknown>, key: string): boolean | null {
+  const v = row[key];
+  return typeof v === "boolean" ? v : null;
 }


### PR DESCRIPTION
Stacked on top of #37 (Backlinks summary). Targets the summary branch so the diff stays focused on milestone 2.

## Summary

Second slice of `docs/DATAFORSEO_BACKLINKS_PHASE2.md`. The cheap summary tile is the dashboard view; this PR adds the per-link **detail** table — the SEMrush / Ahrefs "Backlinks" workhorse — with a recursive **filter DSL** that the visual builder (future milestone) will share.

### Filter DSL — `domain/filters.rs`

- Recursive `Filter::Condition` / `Filter::Group` enum mirroring DataForSEO's on-the-wire shape exactly.
- `Operator` covers the full DataForSEO set (`=`, `<>`, `>`, `<`, `>=`, `<=`, `in`, `not_in`, `like`, `not_like`, `ilike`, `not_ilike`, `match`, `not_match`) — negations use underscores per the Phase 1 review feedback.
- `to_wire()` walks the tree once and produces the alternating filter | `"and"`/`"or"` | filter array DataForSEO accepts.
- Six unit tests: simple condition, negation operator, AND group, nested group, single-node unwrap, empty group.
- ts-rs export so the visual filter-builder builds the same shape on the frontend with no separate translation layer.

### Backend — `api/backlinks.rs` + `commands/backlinks.rs`

- **Registers the `api::backlinks` module in `api/mod.rs`** — this was missing from #37; the PR works locally but the unused module wasn't being type-checked. Fix lands here so detail + summary share the registration.
- `backlinks_live()` POSTs to `/v3/backlinks/backlinks/live` with the optional filter wrapped correctly: a leaf condition gets DataForSEO's required outer array (`[[field, op, value]]`); a group is already in the right shape from `to_wire()`.
- `backlinks_detail` Tauri command validates `mode` + `status` string enums on the Rust side (so a frontend typo produces a clear `Validation` error instead of a silent DataForSEO 40xxx), clamps `limit` to `1..=1000`, and runs through `run_with_ledger` so the cost lands in `/usage`.

### Frontend — `BacklinksPage.tsx`

- Page is now tabbed: **Summary** (existing tile view) + **Detail** (new).
- Detail tab: target input, **preset dropdown** (All / Dofollow only / Domain rank > 30 / Lost links), mode + status selects, limit input with cost preview, items table rendering Source / Anchor / Target / Rank / Type / Dofollow columns.
- Lost-links preset auto-locks status to `"lost"` since the endpoint expresses that via `backlinks_status_type`, not a filter.
- Full visual filter-builder UI is deferred to a separate milestone — presets cover the common cases without bundling the builder in this PR.

### Cost

A 100-row detail call is ~0.023 USD (0.02 base + 100 × 0.00003). Default limit is 100 so the typical "show me this site's links" exploration costs ~2 cents per call.

## Test plan

- [ ] `cargo test -p dataforseo-app` — 6 new filter unit tests pass alongside the existing cost / store tests
- [ ] In the running app, load Summary tab on `example.com` (existing path)
- [ ] Switch to Detail tab, run with each preset and verify the table populates
- [ ] Run with the "Lost links" preset and confirm the status select locks to `lost`
- [ ] Check `/usage` shows the new `backlinks.detail` endpoint rows with non-zero cost
- [ ] Confirm CostPreview updates when limit changes (100 → 1000 → 0.05 USD)


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_