### PR TITLE
feat(dataforseo-app): full endpoint catalogue + Backlinks Domain Intersection (Link Gap)

### DIFF
--- a/apps/dataforseo-app/docs/DATAFORSEO_API_ENDPOINTS.md
+++ b/apps/dataforseo-app/docs/DATAFORSEO_API_ENDPOINTS.md
@@ -129,7 +129,7 @@ across this family (DataForSEO restriction).
 | Referring Domains | `/v3/backlinks/referring_domains/live` | 0.02 + 0.00003/row | ✅ done |
 | Anchors | `/v3/backlinks/anchors/live` | 0.02 + 0.00003/row | ✅ done |
 | History | `/v3/backlinks/history/live` | 0.02 + 0.00003/row | ✅ done |
-| Domain Intersection (Link Gap) | `/v3/backlinks/domain_intersection/live` | 0.02 + 0.00003/row | 🟡 next (this PR) |
+| Domain Intersection (Link Gap) | `/v3/backlinks/domain_intersection/live` | 0.02 + 0.00003/row | ✅ done |
 | Page Intersection | `/v3/backlinks/page_intersection/live` | 0.02 + 0.00003/row | 🟡 next |
 | Domain Pages | `/v3/backlinks/domain_pages/live` | 0.02 + 0.00003/row | 🟡 next |
 | Domain Pages Summary | `/v3/backlinks/domain_pages_summary/live` | 0.02 + 0.00003/row | 🟦 plan |

--- a/apps/dataforseo-app/docs/DATAFORSEO_API_ENDPOINTS.md
+++ b/apps/dataforseo-app/docs/DATAFORSEO_API_ENDPOINTS.md
@@ -1,0 +1,302 @@
+# DataForSEO API — Endpoint Catalogue
+
+Exhaustive list of DataForSEO endpoint families and per-endpoint paths, with
+implementation status in this app, current pricing (USD per request, as of
+2026 Q2), and notes on what each one is good for. The catalogue is the
+"all endpoints" reference; the **Status** column tracks what's wired through
+the Rust backend and surfaced in the UI.
+
+Status legend:
+
+- **✅ done** — Tauri command, cost ledger, UI surface.
+- **🟡 next** — Implementation candidate for an upcoming PR. No
+  architectural blockers; just code.
+- **🟦 plan** — Future milestone. Needs a UI design / new schema /
+  separate cost model.
+- **⛔ skip** — Out of scope for this app (e.g. requires a long-running
+  pipeline, a niche use case, or a different product surface).
+- **n/a** — Sandbox / merchant-facing endpoint we have no use case for.
+
+Pricing notation:
+
+- `Live` rows are the synchronous-response variants (`/live`).
+- `Standard` is the queued variant (`task_post` → `tasks_ready` →
+  `task_get`); typically one third of Live cost.
+- `Priority` is a faster queue (typically 2× standard).
+- Per-row costs (where applicable) are listed in parentheses.
+
+## Keywords Data API
+
+Google Ads search-volume data and clickstream-derived stats.
+
+| Endpoint | Path | Live | Standard | Status |
+| --- | --- | --- | --- | --- |
+| Google Ads · Search Volume | `/v3/keywords_data/google_ads/search_volume/live` | 0.075 / 1k kw | 0.05 / 1k | ✅ done |
+| Google Ads · Keywords for Site | `/v3/keywords_data/google_ads/keywords_for_site/live` | 0.075 | 0.05 | 🟡 next |
+| Google Ads · Keywords for Keywords | `/v3/keywords_data/google_ads/keywords_for_keywords/live` | 0.075 | 0.05 | 🟡 next |
+| Google Ads · Ad Traffic by Keywords | `/v3/keywords_data/google_ads/ad_traffic_by_keywords/live` | 0.075 | 0.05 | 🟦 plan |
+| Google Trends · Explore | `/v3/keywords_data/google_trends/explore/live` | 0.05 | — | 🟡 next |
+| Google Trends · Categories | `/v3/keywords_data/google_trends/categories` | 0.0001 | — | 🟦 plan |
+| Bing · Keyword Performance | `/v3/keywords_data/bing/keyword_performance/live` | 0.05 | — | 🟦 plan |
+| Bing · Search Volume | `/v3/keywords_data/bing/search_volume/live` | 0.05 | — | 🟦 plan |
+| Bing · Locations | `/v3/keywords_data/bing/locations` | free | — | n/a |
+| Clickstream · Bulk Search Volume | `/v3/keywords_data/clickstream_data/bulk_search_volume/live` | 0.0006 / kw | — | 🟡 next |
+| Clickstream · Dataforseo Search Volume | `/v3/keywords_data/dataforseo_trends/explore/live` | 0.05 | — | 🟦 plan |
+
+## DataForSEO Labs API
+
+Aggregated competitive-intel data (no real-time SERP scraping, derived from
+DataForSEO's own crawl).
+
+| Endpoint | Path | Live | Status |
+| --- | --- | --- | --- |
+| Google · Keyword Suggestions | `/v3/dataforseo_labs/google/keyword_suggestions/live` | 0.0125 | ✅ done |
+| Google · Related Keywords | `/v3/dataforseo_labs/google/related_keywords/live` | 0.0125 / depth | ✅ done |
+| Google · Keywords for Site | `/v3/dataforseo_labs/google/keywords_for_site/live` | 0.0125 | ✅ done |
+| Google · Ranked Keywords | `/v3/dataforseo_labs/google/ranked_keywords/live` | 0.0125 | ✅ done |
+| Google · SERP Competitors | `/v3/dataforseo_labs/google/serp_competitors/live` | 0.0125 | 🟡 next |
+| Google · Competitors Domain | `/v3/dataforseo_labs/google/competitors_domain/live` | 0.0125 | 🟡 next |
+| Google · Domain Intersection | `/v3/dataforseo_labs/google/domain_intersection/live` | 0.0125 | 🟡 next |
+| Google · Subdomains | `/v3/dataforseo_labs/google/subdomains/live` | 0.0125 | 🟦 plan |
+| Google · Relevant Pages | `/v3/dataforseo_labs/google/relevant_pages/live` | 0.0125 | 🟦 plan |
+| Google · Page Intersection | `/v3/dataforseo_labs/google/page_intersection/live` | 0.0125 | 🟦 plan |
+| Google · Domain Rank Overview | `/v3/dataforseo_labs/google/domain_rank_overview/live` | 0.0125 | 🟡 next |
+| Google · Historical Rank Overview | `/v3/dataforseo_labs/google/historical_rank_overview/live` | 0.0125 | 🟦 plan |
+| Google · Bulk Keyword Difficulty | `/v3/dataforseo_labs/google/bulk_keyword_difficulty/live` | 0.0001 / kw | 🟡 next |
+| Google · Bulk Search Volume | `/v3/dataforseo_labs/google/bulk_search_volume/live` | 0.0001 / kw | 🟡 next |
+| Google · Search Intent | `/v3/dataforseo_labs/google/search_intent/live` | 0.0125 | 🟡 next |
+| Google · Keyword Overview | `/v3/dataforseo_labs/google/keyword_overview/live` | 0.0125 | 🟡 next |
+| Google · Keyword Ideas | `/v3/dataforseo_labs/google/keyword_ideas/live` | 0.0125 | 🟦 plan |
+| Google · Categories For Domain | `/v3/dataforseo_labs/google/categories_for_domain/live` | 0.0001 | 🟦 plan |
+| Google · Categories For Keywords | `/v3/dataforseo_labs/google/categories_for_keywords/live` | 0.0001 | 🟦 plan |
+| Google · Top Searches | `/v3/dataforseo_labs/google/top_searches/live` | 0.0125 | 🟦 plan |
+| Bing variants | `/v3/dataforseo_labs/bing/...` (mirror of Google) | 0.0125 | 🟦 plan |
+| Amazon variants | `/v3/dataforseo_labs/amazon/...` | 0.0125 | 🟦 plan |
+| Locations / Languages | `/v3/dataforseo_labs/google/locations_and_languages` | free | n/a |
+
+## SERP API
+
+Real-time SERP scraping. The Live and Task variants return identical
+schemas; Live is faster but ~3.3× more expensive. Per-page depth (10/20/
+.../100) multiplies the cost; extra params (`load_async_ai_overview`,
+`people_also_ask_click_depth`, `calculate_rectangles`) multiply by 5×
+each.
+
+| Endpoint | Path | Live (per row) | Standard | Status |
+| --- | --- | --- | --- | --- |
+| Google · Organic | `/v3/serp/google/organic/{live,task_post,task_get/...}` | 0.002 | 0.0006 | ✅ done |
+| Google · Organic AI Mode | `/v3/serp/google/ai_mode/{live,task_post,...}` | 0.002 | 0.0006 | 🟡 next |
+| Google · Ads | `/v3/serp/google/ads/{live,task_post,...}` | 0.002 | 0.0006 | 🟡 next |
+| Google · News | `/v3/serp/google/news/{live,task_post,...}` | 0.002 | 0.0006 | 🟡 next |
+| Google · Maps | `/v3/serp/google/maps/{live,task_post,...}` | 0.002 | 0.0006 | 🟡 next |
+| Google · Local Pack | `/v3/serp/google/local_pack/{live,task_post,...}` | 0.002 | 0.0006 | 🟦 plan |
+| Google · Images | `/v3/serp/google/images/{live,task_post,...}` | 0.002 | 0.0006 | 🟦 plan |
+| Google · Events | `/v3/serp/google/events/{live,task_post,...}` | 0.002 | 0.0006 | 🟦 plan |
+| Google · Jobs | `/v3/serp/google/jobs/{live,task_post,...}` | 0.002 | 0.0006 | 🟦 plan |
+| Google · Finance Explore | `/v3/serp/google/finance_explore/{live,task_post,...}` | 0.002 | 0.0006 | ⛔ skip |
+| Google · Trends · Explore | `/v3/serp/google/google_trends_explore/{live,...}` | 0.002 | 0.0006 | 🟦 plan |
+| Google · Hotels | `/v3/serp/google/hotels/{live,task_post,...}` | 0.002 | 0.0006 | ⛔ skip |
+| Google · Flights | `/v3/serp/google/flights/{live,task_post,...}` | 0.002 | 0.0006 | ⛔ skip |
+| Google · Autocomplete | `/v3/serp/google/autocomplete/{live,task_post,...}` | 0.002 | 0.0006 | 🟡 next |
+| Google · Dataset | `/v3/serp/google/dataset_info/{live,...}` | 0.002 | — | ⛔ skip |
+| Google · Books | `/v3/serp/google/books/{live,task_post,...}` | 0.002 | 0.0006 | ⛔ skip |
+| Bing · Organic | `/v3/serp/bing/organic/{live,task_post,...}` | 0.002 | 0.0006 | 🟡 next |
+| Bing · Local Pack | `/v3/serp/bing/local_pack/{live,task_post,...}` | 0.002 | 0.0006 | 🟦 plan |
+| Yahoo · Organic | `/v3/serp/yahoo/organic/{live,task_post,...}` | 0.002 | 0.0006 | 🟦 plan |
+| YouTube · Organic | `/v3/serp/youtube/organic/{live,task_post,...}` | 0.002 | 0.0006 | 🟦 plan |
+| YouTube · Video Info | `/v3/serp/youtube/video_info/{live,task_post,...}` | 0.002 | 0.0006 | 🟦 plan |
+| YouTube · Video Subtitles | `/v3/serp/youtube/video_subtitles/{live,task_post,...}` | 0.002 | 0.0006 | 🟦 plan |
+| Naver · Organic | `/v3/serp/naver/organic/{live,task_post,...}` | 0.002 | 0.0006 | ⛔ skip |
+| Seznam · Organic | `/v3/serp/seznam/organic/{live,task_post,...}` | 0.002 | 0.0006 | ⛔ skip |
+| Baidu · Organic | `/v3/serp/baidu/organic/{live,task_post,...}` | 0.002 | 0.0006 | ⛔ skip |
+| Yandex · Organic | `/v3/serp/yandex/organic/{live,task_post,...}` | 0.002 | 0.0006 | ⛔ skip |
+| AI Overview · Live | `/v3/serp/google/ai_overview/live/...` | 0.0001 / pull | — | 🟡 next |
+
+> Note: Standard queue endpoints follow the pattern `task_post → tasks_ready
+> → task_get/{advanced,html,regular,...}`. The poller in `tasks::poller`
+> handles the lifecycle; per-search-engine variants only need a new
+> `task_post` URL and a `task_get` URL.
+
+## Backlinks API
+
+Aggregate and per-link inbound-link data. 100 USD/month minimum spend
+across this family (DataForSEO restriction).
+
+| Endpoint | Path | Live | Status |
+| --- | --- | --- | --- |
+| Summary | `/v3/backlinks/summary/live` | 0.02 + 0.00003/row | ✅ done |
+| Backlinks (detail) | `/v3/backlinks/backlinks/live` | 0.02 + 0.00003/row | ✅ done |
+| Referring Domains | `/v3/backlinks/referring_domains/live` | 0.02 + 0.00003/row | ✅ done |
+| Anchors | `/v3/backlinks/anchors/live` | 0.02 + 0.00003/row | ✅ done |
+| History | `/v3/backlinks/history/live` | 0.02 + 0.00003/row | ✅ done |
+| Domain Intersection (Link Gap) | `/v3/backlinks/domain_intersection/live` | 0.02 + 0.00003/row | 🟡 next (this PR) |
+| Page Intersection | `/v3/backlinks/page_intersection/live` | 0.02 + 0.00003/row | 🟡 next |
+| Domain Pages | `/v3/backlinks/domain_pages/live` | 0.02 + 0.00003/row | 🟡 next |
+| Domain Pages Summary | `/v3/backlinks/domain_pages_summary/live` | 0.02 + 0.00003/row | 🟦 plan |
+| Referring Networks | `/v3/backlinks/referring_networks/live` | 0.02 + 0.00003/row | 🟦 plan |
+| Bulk Backlinks | `/v3/backlinks/bulk_backlinks/live` | 0.02 / target | 🟦 plan |
+| Bulk Referring Domains | `/v3/backlinks/bulk_referring_domains/live` | 0.02 / target | 🟦 plan |
+| Bulk Ranks | `/v3/backlinks/bulk_ranks/live` | 0.02 / target | 🟦 plan |
+| Bulk Spam Score | `/v3/backlinks/bulk_spam_score/live` | 0.02 / target | 🟦 plan |
+| Bulk New / Lost | `/v3/backlinks/bulk_new_lost_backlinks/live` | 0.02 / target | 🟦 plan |
+| Available Filters | `/v3/backlinks/available_filters` | free | 🟦 plan (drives builder UI) |
+| Errors | `/v3/backlinks/errors` | free | 🟦 plan (debugging) |
+
+## On-Page API
+
+Site-wide audits — Lighthouse, content parsing, link graphs. Live variants
+are single-page; the Task variants run a multi-page crawl.
+
+| Endpoint | Path | Live | Status |
+| --- | --- | --- | --- |
+| Instant Pages | `/v3/on_page/instant_pages` | 0.0025 / page | 🟡 next |
+| Lighthouse · Live · JSON | `/v3/on_page/lighthouse/live/json` | 0.0025 | 🟡 next |
+| Lighthouse · Audits | `/v3/on_page/lighthouse/audits` | free | 🟦 plan |
+| Lighthouse · Versions | `/v3/on_page/lighthouse/versions` | free | n/a |
+| Task Post (full crawl) | `/v3/on_page/task_post` | 0.000125 / page | 🟦 plan |
+| Pages | `/v3/on_page/pages` | 0.0001 / row | 🟦 plan |
+| Pages By Resource | `/v3/on_page/pages_by_resource` | 0.0001 / row | 🟦 plan |
+| Resources | `/v3/on_page/resources` | 0.0001 / row | 🟦 plan |
+| Duplicate Tags | `/v3/on_page/duplicate_tags` | 0.0001 / row | 🟦 plan |
+| Duplicate Content | `/v3/on_page/duplicate_content` | 0.0001 / row | 🟦 plan |
+| Links | `/v3/on_page/links` | 0.0001 / row | 🟦 plan |
+| Non-indexable | `/v3/on_page/non_indexable` | 0.0001 / row | 🟦 plan |
+| Redirect Chains | `/v3/on_page/redirect_chains` | 0.0001 / row | 🟦 plan |
+| Microdata | `/v3/on_page/microdata` | 0.0001 / row | 🟦 plan |
+| Keyword Density | `/v3/on_page/keyword_density` | 0.0001 / row | 🟦 plan |
+| Content Parsing · Live | `/v3/on_page/content_parsing/live` | 0.0025 | 🟦 plan |
+
+## Domain Analytics API
+
+Tech-stack and WHOIS lookups. Tiny, cheap, useful for one-off audits.
+
+| Endpoint | Path | Live | Status |
+| --- | --- | --- | --- |
+| Technologies · Domain Technologies | `/v3/domain_analytics/technologies/domain_technologies/live` | 0.001 | 🟡 next |
+| Technologies · Available Filters | `/v3/domain_analytics/technologies/available_filters` | free | n/a |
+| Technologies · Domains by Technology | `/v3/domain_analytics/technologies/domains_by_technology/live` | 0.001 | 🟦 plan |
+| Technologies · Aggregation | `/v3/domain_analytics/technologies/aggregation_technologies/live` | 0.001 | 🟦 plan |
+| Whois · Overview | `/v3/domain_analytics/whois/overview/live` | 0.0001 | 🟡 next |
+| Whois · Available Filters | `/v3/domain_analytics/whois/available_filters` | free | n/a |
+
+## Content Analysis API
+
+Brand-mention monitoring across the open web.
+
+| Endpoint | Path | Live | Status |
+| --- | --- | --- | --- |
+| Search | `/v3/content_analysis/search/live` | 0.001 / row | 🟦 plan |
+| Summary | `/v3/content_analysis/summary/live` | 0.001 | 🟦 plan |
+| Sentiment Analysis | `/v3/content_analysis/sentiment_analysis/live` | 0.0005 / row | 🟦 plan |
+| Rating Distribution | `/v3/content_analysis/rating_distribution/live` | 0.0005 | 🟦 plan |
+| Phrase Trends | `/v3/content_analysis/phrase_trends/live` | 0.0005 / row | 🟦 plan |
+| Categories | `/v3/content_analysis/category_trends/live` | 0.0005 | 🟦 plan |
+
+## Content Generation API
+
+LLM-backed text generation. We run our own Anthropic / OpenAI providers
+through the AI panel — DataForSEO's content gen would be a fallback only.
+
+| Endpoint | Path | Live | Status |
+| --- | --- | --- | --- |
+| Generate | `/v3/content_generation/generate/live` | 0.005 / 1k tok | ⛔ skip |
+| Generate Sub-topics | `/v3/content_generation/generate_sub_topics/live` | 0.005 | ⛔ skip |
+| Generate Meta Tags | `/v3/content_generation/generate_meta_tags/live` | 0.005 | ⛔ skip |
+| Paraphrase | `/v3/content_generation/paraphrase/live` | 0.005 | ⛔ skip |
+| Check Grammar | `/v3/content_generation/check_grammar/live` | 0.001 | ⛔ skip |
+| Text Summary | `/v3/content_generation/text_summary/live` | 0.005 | ⛔ skip |
+
+## Merchant API
+
+Marketplace SERPs and product info.
+
+| Endpoint | Path | Live | Status |
+| --- | --- | --- | --- |
+| Amazon · Products | `/v3/merchant/amazon/products/{live,task_post,...}` | 0.002 | 🟦 plan |
+| Amazon · Sellers | `/v3/merchant/amazon/sellers/{live,task_post,...}` | 0.002 | 🟦 plan |
+| Amazon · ASIN | `/v3/merchant/amazon/asin/{live,task_post,...}` | 0.002 | 🟦 plan |
+| Google Shopping · Products | `/v3/merchant/google/products/{live,task_post,...}` | 0.002 | 🟦 plan |
+| Google Shopping · Sellers | `/v3/merchant/google/sellers/{live,task_post,...}` | 0.002 | 🟦 plan |
+
+## App Data API
+
+Mobile app store SERPs and app metadata.
+
+| Endpoint | Path | Live | Status |
+| --- | --- | --- | --- |
+| Google Play · App Searches | `/v3/app_data/google/app_searches/{live,task_post,...}` | 0.002 | 🟦 plan |
+| Google Play · App Reviews | `/v3/app_data/google/app_reviews/{live,task_post,...}` | 0.002 | 🟦 plan |
+| App Store · App Searches | `/v3/app_data/apple/app_searches/{live,task_post,...}` | 0.002 | 🟦 plan |
+| App Store · App Reviews | `/v3/app_data/apple/app_reviews/{live,task_post,...}` | 0.002 | 🟦 plan |
+
+## Business Data API
+
+Local business data and reviews — TripAdvisor, Yelp, Google My Business.
+
+| Endpoint | Path | Live | Status |
+| --- | --- | --- | --- |
+| Google · My Business Info | `/v3/business_data/google/my_business_info/{live,task_post,...}` | 0.0025 | 🟦 plan |
+| Google · My Business Updates | `/v3/business_data/google/my_business_updates/{live,task_post,...}` | 0.0025 | 🟦 plan |
+| Google · Reviews | `/v3/business_data/google/reviews/{live,task_post,...}` | 0.002 | 🟦 plan |
+| Google · Hotels Info | `/v3/business_data/google/hotels/info/{live,task_post,...}` | 0.002 | ⛔ skip |
+| Google · Questions Search | `/v3/business_data/google/questions_search/{live,task_post,...}` | 0.002 | 🟦 plan |
+| Google · Extended Reviews | `/v3/business_data/google/extended_reviews/{live,task_post,...}` | 0.002 | 🟦 plan |
+| TripAdvisor · Search | `/v3/business_data/tripadvisor/search/{live,task_post,...}` | 0.002 | ⛔ skip |
+| TripAdvisor · Reviews | `/v3/business_data/tripadvisor/reviews/{live,task_post,...}` | 0.002 | ⛔ skip |
+| Trustpilot · Search | `/v3/business_data/trustpilot/search/{live,task_post,...}` | 0.002 | 🟦 plan |
+| Trustpilot · Reviews | `/v3/business_data/trustpilot/reviews/{live,task_post,...}` | 0.002 | 🟦 plan |
+| Yelp · Search | `/v3/business_data/yelp/search/{live,task_post,...}` | 0.002 | 🟦 plan |
+| Social Media · Pinterest | `/v3/business_data/social_media/pinterest/live` | 0.0001 | 🟦 plan |
+| Social Media · Facebook | `/v3/business_data/social_media/facebook/live` | 0.0001 | 🟦 plan |
+| Social Media · Reddit | `/v3/business_data/social_media/reddit/live` | 0.0001 | 🟦 plan |
+
+## AI Optimization API
+
+Newer family that tracks AI Overview / SGE / Perplexity-style answer
+inclusion. Pricing model still in flux at DataForSEO; we'll wire it once
+the prices stabilise.
+
+| Endpoint | Path | Live | Status |
+| --- | --- | --- | --- |
+| ChatGPT · LLM Responses | `/v3/ai_optimization/chat_gpt/llm_responses/live` | 0.005 / call | 🟦 plan |
+| Perplexity · LLM Responses | `/v3/ai_optimization/perplexity/llm_responses/live` | 0.005 | 🟦 plan |
+| Gemini · LLM Responses | `/v3/ai_optimization/gemini/llm_responses/live` | 0.005 | 🟦 plan |
+| Claude · LLM Responses | `/v3/ai_optimization/claude/llm_responses/live` | 0.005 | 🟦 plan |
+| AI Keyword Data · Search Volume | `/v3/ai_optimization/ai_keyword_data/keyword_data/live` | 0.0001 / kw | 🟦 plan |
+
+## Account / Appendix endpoints
+
+Always free. Used by the auth + diagnostics flows.
+
+| Endpoint | Path | Status |
+| --- | --- | --- |
+| User Data | `/v3/appendix/user_data` | ✅ done (auth.test_connection) |
+| Errors | `/v3/appendix/errors` | 🟦 plan |
+| Status | `/v3/appendix/status` | 🟦 plan |
+| Webhook | `/v3/appendix/webhook/{post,delete}` | ⛔ skip |
+
+---
+
+## Implementation roadmap
+
+After this PR (Domain Intersection), the suggested order for the next batch
+is:
+
+1. **Backlinks · page_intersection + domain_pages** (closes Backlinks
+   Phase 2 entirely; reuses the existing tab shell).
+2. **Domain Analytics · whois + technologies** (small new page, two
+   cheap endpoints, gives users a quick "what's this domain running"
+   answer).
+3. **Labs · domain_rank_overview + bulk_keyword_difficulty** (rounds
+   out the keyword research path with the SEMrush "domain overview"
+   tile).
+4. **SERP · ads + news + maps** (extra SERP variants; same pipeline as
+   organic, just new task_post URLs).
+5. **On-Page · instant_pages + lighthouse** (one-page audits without
+   a full crawl; useful as a chat-attached diagnostic).
+6. **AI Optimization** (whole family) once DataForSEO stabilises prices.
+7. **Visual filter-builder UI** for the Backlinks family (replaces
+   the preset dropdown in the Detail tab).
+
+Each of those is a single PR's worth of work and each can be reviewed
+without blocking the others.

--- a/apps/dataforseo-app/src-tauri/src/api/backlinks.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/backlinks.rs
@@ -327,4 +327,79 @@ impl ApiClient {
             cost,
         })
     }
+
+    /// Domain Intersection — the SEMrush "Link Gap" feature. Pass two
+    /// targets and `intersection_mode = "intersect"` to get domains that
+    /// link to both, or `"exclude"` to get domains that link only to the
+    /// first target. The shape is the same as referring_domains: one row
+    /// per linking domain with rank, backlink count, etc.
+    pub async fn backlinks_domain_intersection_live(
+        &self,
+        args: BacklinksIntersectionArgs<'_>,
+    ) -> Result<BacklinksListResponse> {
+        let mut payload = serde_json::json!({
+            "targets": [
+                { "target": args.target_a, "include_subdomains": args.include_subdomains },
+                { "target": args.target_b, "include_subdomains": args.include_subdomains },
+            ],
+            "intersection_mode": args.intersection_mode,
+            "limit": args.limit,
+            "offset": args.offset,
+        });
+        if let Some(filter) = args.filter {
+            attach_filter(&mut payload, filter);
+        }
+        if let Some(order) = args.order_by {
+            payload["order_by"] = serde_json::json!(order);
+        }
+        let body = serde_json::json!([payload]);
+        let raw = self
+            .post_json(
+                Family::Backlinks,
+                "/v3/backlinks/domain_intersection/live",
+                &body,
+            )
+            .await?;
+        let cost = ensure_api_success(&raw)?;
+        let result = raw.pointer("/tasks/0/result/0").ok_or_else(|| {
+            AppError::Parse("backlinks domain_intersection missing tasks[0].result[0]".into())
+        })?;
+        let total_count = result
+            .pointer("/total_count")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        let items_count = result
+            .pointer("/items_count")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        let items = result
+            .pointer("/items")
+            .cloned()
+            .unwrap_or(Value::Array(Vec::new()));
+        Ok(BacklinksListResponse {
+            // Combine the two targets into the response label so the UI
+            // can show "a vs b" without storing them separately.
+            target: format!("{} vs {}", args.target_a, args.target_b),
+            total_count,
+            items_count,
+            items,
+            cost,
+        })
+    }
+}
+
+/// Inputs for `backlinks_domain_intersection_live`. Two targets and a mode
+/// — "intersect" (linking domains in common) or "exclude" (domains linking
+/// to A but not B). Filterable like the other list endpoints.
+#[derive(Debug, Clone)]
+pub struct BacklinksIntersectionArgs<'a> {
+    pub target_a: &'a str,
+    pub target_b: &'a str,
+    /// "intersect" | "exclude" — DataForSEO's wire form.
+    pub intersection_mode: &'static str,
+    pub limit: u32,
+    pub offset: u32,
+    pub include_subdomains: bool,
+    pub filter: Option<&'a Filter>,
+    pub order_by: Option<Vec<String>>,
 }

--- a/apps/dataforseo-app/src-tauri/src/commands/backlinks.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/backlinks.rs
@@ -5,7 +5,9 @@ use tauri::State;
 use tokio::task;
 use ts_rs::TS;
 
-use crate::api::backlinks::{BacklinksDetailArgs, BacklinksListArgs};
+use crate::api::backlinks::{
+    BacklinksDetailArgs, BacklinksIntersectionArgs, BacklinksListArgs,
+};
 use crate::commands::ledger::run_with_ledger;
 use crate::domain::cost::{self, CostAction};
 use crate::domain::endpoints;
@@ -396,6 +398,93 @@ pub async fn backlinks_history(
                     date_to.as_deref(),
                 )
                 .await?;
+            let cost = r.cost;
+            Ok((r, cost))
+        },
+    )
+    .await?;
+
+    Ok(BacklinksListView {
+        target: resp.target,
+        total_count: resp.total_count,
+        items_count: resp.items_count,
+        items: resp.items,
+        cost_usd: resp.cost,
+        estimated_usd,
+    })
+}
+
+// ---------- Domain Intersection (Link Gap) ----------
+
+#[derive(Debug, Clone, Deserialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+#[serde(rename_all = "camelCase")]
+pub struct BacklinksIntersectionParams {
+    pub target_a: String,
+    pub target_b: String,
+    /// "intersect" (domains linking to both) | "exclude" (linking to A
+    /// but not B). The frontend toggles between these.
+    pub intersection_mode: String,
+    pub limit: u32,
+    pub offset: u32,
+    pub include_subdomains: bool,
+    pub filter: Option<Filter>,
+    pub order_by: Option<Vec<String>>,
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state, params))]
+pub async fn backlinks_domain_intersection(
+    state: State<'_, AppState>,
+    params: BacklinksIntersectionParams,
+) -> Result<BacklinksListView> {
+    let target_a = params.target_a.trim().to_owned();
+    let target_b = params.target_b.trim().to_owned();
+    if target_a.is_empty() || target_b.is_empty() {
+        return Err(AppError::Validation(
+            "both targets required".into(),
+        ));
+    }
+    let mode = match params.intersection_mode.as_str() {
+        "intersect" => "intersect",
+        "exclude" => "exclude",
+        other => {
+            return Err(AppError::Validation(format!(
+                "invalid intersection_mode {other:?}; expected intersect|exclude"
+            )))
+        }
+    };
+    let limit = params.limit.clamp(1, LIST_MAX_LIMIT);
+
+    // Same per-row pricing as referring_domains.
+    let estimated_usd = cost::estimate(&CostAction::Backlinks {
+        target_count: 1,
+        rows_per_target: limit,
+    });
+
+    let api = state.api.clone();
+    let filter = params.filter.clone();
+    let order_by = params.order_by.clone();
+    let target_a_for_call = target_a.clone();
+    let target_b_for_call = target_b.clone();
+    let resp = run_with_ledger(
+        state.store.clone(),
+        endpoints::BACKLINKS_DOMAIN_INTERSECTION,
+        Mode::Live,
+        estimated_usd,
+        limit as i64,
+        move || async move {
+            let args = BacklinksIntersectionArgs {
+                target_a: &target_a_for_call,
+                target_b: &target_b_for_call,
+                intersection_mode: mode,
+                limit,
+                offset: params.offset,
+                include_subdomains: params.include_subdomains,
+                filter: filter.as_ref(),
+                order_by,
+            };
+            let r = api.backlinks_domain_intersection_live(args).await?;
             let cost = r.cost;
             Ok((r, cost))
         },

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -56,6 +56,7 @@ pub fn run() {
             commands::backlinks::backlinks_referring_domains,
             commands::backlinks::backlinks_anchors,
             commands::backlinks::backlinks_history,
+            commands::backlinks::backlinks_domain_intersection,
             commands::ai::ai_provider_status,
             commands::ai::ai_save_provider_key,
             commands::ai::ai_clear_provider_key,

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -112,6 +112,9 @@ export const tauriApi = {
   backlinksHistory: (params: BacklinksHistoryParams) =>
     invoke<BacklinksListView>("backlinks_history", { params }),
 
+  backlinksDomainIntersection: (params: BacklinksIntersectionParams) =>
+    invoke<BacklinksListView>("backlinks_domain_intersection", { params }),
+
   getRecentCalls: (args: { limit: number }) =>
     invoke<CallLogRow[]>("get_recent_calls", args),
 
@@ -334,6 +337,19 @@ export interface BacklinksHistoryParams {
   // YYYY-MM-DD; both ends optional.
   dateFrom: string | null;
   dateTo: string | null;
+}
+
+export type BacklinksIntersectionMode = "intersect" | "exclude";
+
+export interface BacklinksIntersectionParams {
+  targetA: string;
+  targetB: string;
+  intersectionMode: BacklinksIntersectionMode;
+  limit: number;
+  offset: number;
+  includeSubdomains: boolean;
+  filter: FilterTree | null;
+  orderBy: string[] | null;
 }
 
 export interface TaskBatchId {

--- a/apps/dataforseo-app/src/routes/BacklinksPage.tsx
+++ b/apps/dataforseo-app/src/routes/BacklinksPage.tsx
@@ -1043,9 +1043,15 @@ function LinkGapTab() {
     if (!a || !b) return;
     setBusy(true);
     try {
+      // DataForSEO's "exclude" mode returns (target_a \ target_b) — i.e.
+      // domains linking to the first target but not the second. To find
+      // the "Link Gap" (the competitor's links the user is missing), we
+      // need to send (competitor \ user), so swap the order when mode is
+      // "exclude". For "intersect" the order doesn't matter (set
+      // intersection is commutative).
       const result = await tauriApi.backlinksDomainIntersection({
-        targetA: a,
-        targetB: b,
+        targetA: mode === "exclude" ? b : a,
+        targetB: mode === "exclude" ? a : b,
         intersectionMode: mode,
         limit,
         offset: 0,
@@ -1057,7 +1063,7 @@ function LinkGapTab() {
       const label =
         mode === "intersect"
           ? `domains linking to both`
-          : `domains linking to ${a} but not ${b}`;
+          : `domains linking to ${b} but not ${a}`;
       toast.success(
         `Loaded ${formatCount(result.items_count)} ${label} (${formatUsd(result.cost_usd)})`,
       );

--- a/apps/dataforseo-app/src/routes/BacklinksPage.tsx
+++ b/apps/dataforseo-app/src/routes/BacklinksPage.tsx
@@ -17,12 +17,19 @@ import {
   type BacklinksDetailMode,
   type BacklinksDetailStatus,
   type BacklinksDetailView,
+  type BacklinksIntersectionMode,
   type BacklinksListView,
   type BacklinksSummaryView,
   type FilterTree,
 } from "../lib/tauri";
 
-type Tab = "summary" | "detail" | "domains" | "anchors" | "history";
+type Tab =
+  | "summary"
+  | "detail"
+  | "domains"
+  | "anchors"
+  | "history"
+  | "linkgap";
 
 export default function BacklinksPage() {
   const [tab, setTab] = useState<Tab>("summary");
@@ -60,6 +67,9 @@ export default function BacklinksPage() {
         <TabButton active={tab === "history"} onClick={() => setTab("history")}>
           History
         </TabButton>
+        <TabButton active={tab === "linkgap"} onClick={() => setTab("linkgap")}>
+          Link Gap
+        </TabButton>
       </nav>
 
       {tab === "summary" && <SummaryTab />}
@@ -67,6 +77,7 @@ export default function BacklinksPage() {
       {tab === "domains" && <ReferringDomainsTab />}
       {tab === "anchors" && <AnchorsTab />}
       {tab === "history" && <HistoryTab />}
+      {tab === "linkgap" && <LinkGapTab />}
     </section>
   );
 }
@@ -1011,6 +1022,192 @@ function EmptyHint({ label }: { label: string }) {
   return (
     <div className="rounded border bg-white p-8 text-center text-sm text-slate-500">
       {label}
+    </div>
+  );
+}
+
+// ---------- Link Gap (Domain Intersection) tab ----------
+
+function LinkGapTab() {
+  const [targetA, setTargetA] = useState("");
+  const [targetB, setTargetB] = useState("");
+  const [mode, setMode] = useState<BacklinksIntersectionMode>("exclude");
+  const [limit, setLimit] = useState(100);
+  const [includeSubdomains, setIncludeSubdomains] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [view, setView] = useState<BacklinksListView | null>(null);
+
+  async function onRun() {
+    const a = targetA.trim();
+    const b = targetB.trim();
+    if (!a || !b) return;
+    setBusy(true);
+    try {
+      const result = await tauriApi.backlinksDomainIntersection({
+        targetA: a,
+        targetB: b,
+        intersectionMode: mode,
+        limit,
+        offset: 0,
+        includeSubdomains,
+        filter: null,
+        orderBy: ["rank,desc"],
+      });
+      setView(result);
+      const label =
+        mode === "intersect"
+          ? `domains linking to both`
+          : `domains linking to ${a} but not ${b}`;
+      toast.success(
+        `Loaded ${formatCount(result.items_count)} ${label} (${formatUsd(result.cost_usd)})`,
+      );
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-xs text-slate-600">
+        SEMrush-style "Link Gap": find domains linking to a competitor but
+        not to you. Pick <strong>exclude</strong> to see {targetB || "B"}'s
+        links that {targetA || "A"} is missing, or <strong>intersect</strong>{" "}
+        to see which referring domains both already share.
+      </p>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_320px]">
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-slate-700">Your domain (A)</span>
+            <input
+              type="text"
+              value={targetA}
+              onChange={(e) => setTargetA(e.target.value)}
+              disabled={busy}
+              className="rounded border px-2 py-1 font-mono text-sm disabled:bg-slate-50"
+              placeholder="example.com"
+              spellCheck={false}
+              autoComplete="off"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-slate-700">
+              Competitor domain (B)
+            </span>
+            <input
+              type="text"
+              value={targetB}
+              onChange={(e) => setTargetB(e.target.value)}
+              disabled={busy}
+              className="rounded border px-2 py-1 font-mono text-sm disabled:bg-slate-50"
+              placeholder="competitor.com"
+              spellCheck={false}
+              autoComplete="off"
+            />
+          </label>
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <label className="flex flex-col gap-1">
+              <span className="font-medium text-slate-700">Mode</span>
+              <select
+                value={mode}
+                onChange={(e) =>
+                  setMode(e.target.value as BacklinksIntersectionMode)
+                }
+                disabled={busy}
+                className="rounded border px-2 py-1 disabled:bg-slate-50"
+              >
+                <option value="exclude">Exclude (B \ A)</option>
+                <option value="intersect">Intersect (A ∩ B)</option>
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="font-medium text-slate-700">Limit</span>
+              <input
+                type="number"
+                min={1}
+                max={1000}
+                value={limit}
+                onChange={(e) => {
+                  const n = e.target.valueAsNumber;
+                  setLimit(Number.isFinite(n) ? n : 0);
+                }}
+                onBlur={(e) => {
+                  const n = e.target.valueAsNumber;
+                  setLimit(
+                    Number.isFinite(n)
+                      ? Math.max(1, Math.min(1000, n))
+                      : 100,
+                  );
+                }}
+                disabled={busy}
+                className="rounded border px-2 py-1 disabled:bg-slate-50"
+              />
+            </label>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <CostPreview
+            action={{
+              kind: "Backlinks",
+              target_count: 1,
+              rows_per_target: limit,
+            }}
+            details={[
+              `Up to ${formatCount(limit)} domains`,
+              mode === "exclude"
+                ? "Domains linking only to B"
+                : "Domains linking to both",
+            ]}
+            disabled={busy || !targetA.trim() || !targetB.trim()}
+          />
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={includeSubdomains}
+              onChange={(e) => setIncludeSubdomains(e.target.checked)}
+              disabled={busy}
+            />
+            Include subdomains
+          </label>
+          <button
+            type="button"
+            onClick={onRun}
+            disabled={busy || !targetA.trim() || !targetB.trim()}
+            className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+          >
+            {busy ? "Loading…" : "Find link gap"}
+          </button>
+        </div>
+      </div>
+
+      {view ? (
+        <ListTable
+          view={view}
+          columns={[
+            { key: "domain", label: "Domain", kind: "string" },
+            { key: "rank", label: "Rank", kind: "number", align: "right" },
+            {
+              key: "backlinks",
+              label: "Links",
+              kind: "number",
+              align: "right",
+            },
+            {
+              key: "first_seen",
+              label: "First seen",
+              kind: "string",
+              transform: (v) => (typeof v === "string" ? v.slice(0, 10) : "—"),
+            },
+          ]}
+        />
+      ) : (
+        !busy && (
+          <EmptyHint label="Enter your domain and a competitor, then find the gap." />
+        )
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Stacked on #39. Two deliverables in one PR:

## 1. `docs/DATAFORSEO_API_ENDPOINTS.md` — exhaustive endpoint catalogue

Every DataForSEO endpoint family, every path, current pricing, and an explicit **status** for each (`done` / `next` / `plan` / `skip` / `n/a`) so the audit doubles as a planning surface. Covers Keywords Data, Labs, SERP, Backlinks, On-Page, Domain Analytics, Content Analysis, Content Generation, Merchant, App Data, Business Data, AI Optimization, and the free Appendix endpoints (~150 entries total).

The doc ends with a numbered **implementation roadmap** so the next 6+ PRs are pre-scoped without needing fresh planning each round.

## 2. Backlinks · `domain_intersection_live` (Link Gap)

The major remaining SEMrush parity feature for the Backlinks family. Pick two domains and find:
- **Exclude (B \ A)** — domains linking to your competitor but not to you (the "what am I missing" view)
- **Intersect (A ∩ B)** — domains linking to both (the "shared backbone" view)

### Backend

- `backlinks_domain_intersection_live` takes two targets and a mode. Reuses `BacklinksListResponse` so the existing `ListTable` component renders the result with no new schema.
- Reuses the Backlinks rate-limit family and the `attach_filter` helper — no new infrastructure needed.
- Tauri command validates the `intersection_mode` enum, clamps `limit` to `1..=1000`, routes through `run_with_ledger`.

### Frontend

- Sixth tab on `BacklinksPage`: **Link Gap**. Two inputs (yours + competitor), a mode select, limit field with the standard `onBlur` clamp.
- Header copy explains "exclude" vs "intersect" so it's not obvious-only-once-you-know.

## Test plan

- [ ] `cargo test -p dataforseo-app` — existing tests pass
- [ ] `cargo build` — new command compiles and registers
- [ ] In the running app, switch to "Link Gap" tab
- [ ] Run on `yourdomain.com` vs a competitor in `exclude` mode — verify only their unique referring domains appear
- [ ] Switch mode to `intersect` — verify only shared domains appear
- [ ] Confirm `/usage` shows a `backlinks.domain_intersection` row
- [ ] Skim the catalogue doc — every endpoint family present, status legend used consistently


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_