### PR TITLE
feat(dataforseo-app): Domain Analytics page (WHOIS + Technologies)

### DIFF
--- a/apps/dataforseo-app/docs/DATAFORSEO_API_ENDPOINTS.md
+++ b/apps/dataforseo-app/docs/DATAFORSEO_API_ENDPOINTS.md
@@ -172,11 +172,11 @@ Tech-stack and WHOIS lookups. Tiny, cheap, useful for one-off audits.
 
 | Endpoint | Path | Live | Status |
 | --- | --- | --- | --- |
-| Technologies · Domain Technologies | `/v3/domain_analytics/technologies/domain_technologies/live` | 0.001 | 🟡 next |
+| Technologies · Domain Technologies | `/v3/domain_analytics/technologies/domain_technologies/live` | 0.001 | ✅ done |
 | Technologies · Available Filters | `/v3/domain_analytics/technologies/available_filters` | free | n/a |
 | Technologies · Domains by Technology | `/v3/domain_analytics/technologies/domains_by_technology/live` | 0.001 | 🟦 plan |
 | Technologies · Aggregation | `/v3/domain_analytics/technologies/aggregation_technologies/live` | 0.001 | 🟦 plan |
-| Whois · Overview | `/v3/domain_analytics/whois/overview/live` | 0.0001 | 🟡 next |
+| Whois · Overview | `/v3/domain_analytics/whois/overview/live` | 0.0001 | ✅ done |
 | Whois · Available Filters | `/v3/domain_analytics/whois/available_filters` | free | n/a |
 
 ## Content Analysis API

--- a/apps/dataforseo-app/src-tauri/src/api/domain_analytics.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/domain_analytics.rs
@@ -1,0 +1,97 @@
+//! DataForSEO Domain Analytics API. Two cheap, one-request endpoints:
+//!
+//! - `whois/overview`: registrar, expiry, name servers, etc. for a list
+//!   of domains. The "list" can be a single name; pricing is 0.0001 USD
+//!   per row returned, so a one-domain lookup costs essentially nothing.
+//! - `technologies/domain_technologies`: tech stack per domain (CMS,
+//!   analytics, ad networks, frameworks). Wappalyzer-style data,
+//!   0.001 USD flat per request.
+
+use serde_json::Value;
+
+use crate::api::client::ApiClient;
+use crate::api::ensure_api_success;
+use crate::errors::{AppError, Result};
+use crate::ratelimit::Family;
+
+#[derive(Debug)]
+pub struct WhoisOverviewResponse {
+    /// Raw items array preserved verbatim — DataForSEO returns a generous
+    /// set of fields (registrar, name servers, dates, status flags) and
+    /// we let the UI render the ones it knows about.
+    pub items: Value,
+    pub items_count: i64,
+    pub total_count: i64,
+    pub cost: f64,
+}
+
+#[derive(Debug)]
+pub struct TechnologiesResponse {
+    /// Single result row with `technologies` map and metadata.
+    pub result: Value,
+    pub cost: f64,
+}
+
+impl ApiClient {
+    /// WHOIS overview for one domain. The endpoint accepts a `targets`
+    /// array, but the UI calls it with a single domain at a time —
+    /// batching is a future feature. Order_by sorts by domain by default.
+    pub async fn whois_overview_live(&self, domain: &str) -> Result<WhoisOverviewResponse> {
+        let body = serde_json::json!([{
+            "targets": [domain],
+            "limit": 1,
+        }]);
+        let raw = self
+            .post_json(
+                Family::DomainAnalytics,
+                "/v3/domain_analytics/whois/overview/live",
+                &body,
+            )
+            .await?;
+        let cost = ensure_api_success(&raw)?;
+        let result = raw.pointer("/tasks/0/result/0").ok_or_else(|| {
+            AppError::Parse("whois overview missing tasks[0].result[0]".into())
+        })?;
+        let items_count = result
+            .pointer("/items_count")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        let total_count = result
+            .pointer("/total_count")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        let items = result
+            .pointer("/items")
+            .cloned()
+            .unwrap_or(Value::Array(Vec::new()));
+        Ok(WhoisOverviewResponse {
+            items,
+            items_count,
+            total_count,
+            cost,
+        })
+    }
+
+    /// Technology stack detected on the given domain. Single-target
+    /// endpoint, returns a `technologies` map keyed by category.
+    pub async fn domain_technologies_live(&self, domain: &str) -> Result<TechnologiesResponse> {
+        let body = serde_json::json!([{
+            "target": domain,
+        }]);
+        let raw = self
+            .post_json(
+                Family::DomainAnalytics,
+                "/v3/domain_analytics/technologies/domain_technologies/live",
+                &body,
+            )
+            .await?;
+        let cost = ensure_api_success(&raw)?;
+        let result = raw
+            .pointer("/tasks/0/result/0")
+            .cloned()
+            .ok_or_else(|| {
+                AppError::Parse("domain_technologies missing tasks[0].result[0]".into())
+            })?;
+        Ok(TechnologiesResponse { result, cost })
+    }
+}

--- a/apps/dataforseo-app/src-tauri/src/api/domain_analytics.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/domain_analytics.rs
@@ -49,19 +49,21 @@ impl ApiClient {
             )
             .await?;
         let cost = ensure_api_success(&raw)?;
-        let result = raw.pointer("/tasks/0/result/0").ok_or_else(|| {
-            AppError::Parse("whois overview missing tasks[0].result[0]".into())
-        })?;
+        // A successful response with an unregistered or privacy-shielded
+        // target returns `result: null` or an empty result array — that's
+        // valid data, not a parse error. Fall through with empty
+        // counts/items so the UI can render its empty-state message.
+        let result = raw.pointer("/tasks/0/result/0");
         let items_count = result
-            .pointer("/items_count")
+            .and_then(|r| r.pointer("/items_count"))
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
         let total_count = result
-            .pointer("/total_count")
+            .and_then(|r| r.pointer("/total_count"))
             .and_then(|v| v.as_i64())
             .unwrap_or(0);
         let items = result
-            .pointer("/items")
+            .and_then(|r| r.pointer("/items"))
             .cloned()
             .unwrap_or(Value::Array(Vec::new()));
         Ok(WhoisOverviewResponse {
@@ -86,12 +88,15 @@ impl ApiClient {
             )
             .await?;
         let cost = ensure_api_success(&raw)?;
+        // Domains DataForSEO has no tech-stack data on (unregistered,
+        // tiny sites, robots.txt-blocked) come back as a successful
+        // response with `result: null`. That's not a parse error — we
+        // pass Null through and let the UI show its "no technologies
+        // detected" state.
         let result = raw
             .pointer("/tasks/0/result/0")
             .cloned()
-            .ok_or_else(|| {
-                AppError::Parse("domain_technologies missing tasks[0].result[0]".into())
-            })?;
+            .unwrap_or(Value::Null);
         Ok(TechnologiesResponse { result, cost })
     }
 }

--- a/apps/dataforseo-app/src-tauri/src/api/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod backlinks;
 pub mod client;
+pub mod domain_analytics;
 pub mod keywords_data;
 pub mod labs;
 pub mod serp;

--- a/apps/dataforseo-app/src-tauri/src/commands/domain_analytics.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/domain_analytics.rs
@@ -1,0 +1,119 @@
+//! Tauri commands for the Domain Analytics family. Two endpoints:
+//! `whois_overview` and `domain_technologies`. Both go through the
+//! standard `run_with_ledger` helper so calls show up in /usage.
+
+use serde::Serialize;
+use serde_json::Value;
+use tauri::State;
+use ts_rs::TS;
+
+use crate::commands::ledger::run_with_ledger;
+use crate::domain::cost::{self, CostAction};
+use crate::domain::endpoints;
+use crate::domain::types::Mode;
+use crate::errors::{AppError, Result};
+use crate::state::AppState;
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct WhoisView {
+    pub domain: String,
+    /// Raw item from DataForSEO. Many fields; the page picks the ones it
+    /// recognises (registrar, dates, name servers, status).
+    pub item: Value,
+    pub cost_usd: f64,
+    pub estimated_usd: f64,
+}
+
+#[derive(Debug, Clone, Serialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct TechnologiesView {
+    pub domain: String,
+    /// Whole result blob — has `domain`, `last_visited_date`,
+    /// `country_iso_code`, `language_code`, `content_language_code`,
+    /// `meta`, and a `technologies` map. UI extracts `technologies`.
+    pub result: Value,
+    pub cost_usd: f64,
+    pub estimated_usd: f64,
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn whois_overview(
+    state: State<'_, AppState>,
+    domain: String,
+) -> Result<WhoisView> {
+    let domain = domain.trim().to_owned();
+    if domain.is_empty() {
+        return Err(AppError::Validation("domain required".into()));
+    }
+    // Single-domain lookup → 1 row → 0.0001 USD baseline.
+    let estimated_usd = cost::estimate(&CostAction::DomainAnalyticsWhois { rows: 1 });
+    let api = state.api.clone();
+    let domain_for_call = domain.clone();
+    let resp = run_with_ledger(
+        state.store.clone(),
+        endpoints::DOMAIN_ANALYTICS_WHOIS_OVERVIEW,
+        Mode::Live,
+        estimated_usd,
+        1,
+        move || async move {
+            let r = api.whois_overview_live(&domain_for_call).await?;
+            let cost = r.cost;
+            Ok((r, cost))
+        },
+    )
+    .await?;
+
+    // Pull out the first item; whois/overview returns one row per target
+    // and we always send a single target. Fall back to Null if the API
+    // returned an empty array for an unregistered/invalid domain.
+    let item = resp
+        .items
+        .as_array()
+        .and_then(|a| a.first())
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    Ok(WhoisView {
+        domain,
+        item,
+        cost_usd: resp.cost,
+        estimated_usd,
+    })
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn domain_technologies(
+    state: State<'_, AppState>,
+    domain: String,
+) -> Result<TechnologiesView> {
+    let domain = domain.trim().to_owned();
+    if domain.is_empty() {
+        return Err(AppError::Validation("domain required".into()));
+    }
+    let estimated_usd = cost::estimate(&CostAction::DomainAnalyticsTechnologies);
+    let api = state.api.clone();
+    let domain_for_call = domain.clone();
+    let resp = run_with_ledger(
+        state.store.clone(),
+        endpoints::DOMAIN_ANALYTICS_TECHNOLOGIES,
+        Mode::Live,
+        estimated_usd,
+        1,
+        move || async move {
+            let r = api.domain_technologies_live(&domain_for_call).await?;
+            let cost = r.cost;
+            Ok((r, cost))
+        },
+    )
+    .await?;
+
+    Ok(TechnologiesView {
+        domain,
+        result: resp.result,
+        cost_usd: resp.cost,
+        estimated_usd,
+    })
+}

--- a/apps/dataforseo-app/src-tauri/src/commands/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod ai;
 pub mod auth;
 pub mod backlinks;
+pub mod domain_analytics;
 pub mod keywords;
 pub mod ledger;
 pub mod serp;

--- a/apps/dataforseo-app/src-tauri/src/domain/cost.rs
+++ b/apps/dataforseo-app/src-tauri/src/domain/cost.rs
@@ -19,6 +19,13 @@ pub enum CostAction {
     /// targets are queried (one POST each), `rows_per_target` the limit
     /// requested. Aggregate endpoints (summary, history) pass rows=1.
     Backlinks { target_count: u32, rows_per_target: u32 },
+    /// Domain Analytics WHOIS · 0.0001 USD per row (one row per domain
+    /// returned). One request can return many rows when filtered.
+    DomainAnalyticsWhois { rows: u32 },
+    /// Domain Analytics Technologies · 0.001 USD per request (the
+    /// per-domain endpoint returns one row per request, so we don't
+    /// multiply by rows here).
+    DomainAnalyticsTechnologies,
 }
 
 pub fn estimate(action: &CostAction) -> f64 {
@@ -64,6 +71,8 @@ pub fn estimate(action: &CostAction) -> f64 {
             total_requests * 0.02
                 + (*target_count as f64 * *rows_per_target as f64) * 0.00003
         }
+        DomainAnalyticsWhois { rows } => (*rows as f64).max(1.0) * 0.0001,
+        DomainAnalyticsTechnologies => 0.001,
     }
 }
 
@@ -147,6 +156,26 @@ mod tests {
             rows_per_target: 100_000,
         });
         assert!(cost > 0.0 && cost.is_finite());
+    }
+
+    #[test]
+    fn whois_overview_one_row_baseline() {
+        let cost = estimate(&CostAction::DomainAnalyticsWhois { rows: 1 });
+        assert!((cost - 0.0001).abs() < 1e-9);
+    }
+
+    #[test]
+    fn whois_overview_zero_rows_still_one_request() {
+        let cost = estimate(&CostAction::DomainAnalyticsWhois { rows: 0 });
+        // .max(1.0) prevents the estimate from going to zero before the
+        // user's first keystroke.
+        assert!((cost - 0.0001).abs() < 1e-9);
+    }
+
+    #[test]
+    fn technologies_is_flat_per_request() {
+        let cost = estimate(&CostAction::DomainAnalyticsTechnologies);
+        assert!((cost - 0.001).abs() < 1e-9);
     }
 
     #[test]

--- a/apps/dataforseo-app/src-tauri/src/domain/endpoints.rs
+++ b/apps/dataforseo-app/src-tauri/src/domain/endpoints.rs
@@ -16,3 +16,5 @@ pub const BACKLINKS_REFERRING_DOMAINS: &str = "backlinks.referring_domains";
 pub const BACKLINKS_ANCHORS: &str = "backlinks.anchors";
 pub const BACKLINKS_HISTORY: &str = "backlinks.history";
 pub const BACKLINKS_DOMAIN_INTERSECTION: &str = "backlinks.domain_intersection";
+pub const DOMAIN_ANALYTICS_WHOIS_OVERVIEW: &str = "domain_analytics.whois.overview";
+pub const DOMAIN_ANALYTICS_TECHNOLOGIES: &str = "domain_analytics.technologies.domain";

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -57,6 +57,8 @@ pub fn run() {
             commands::backlinks::backlinks_anchors,
             commands::backlinks::backlinks_history,
             commands::backlinks::backlinks_domain_intersection,
+            commands::domain_analytics::whois_overview,
+            commands::domain_analytics::domain_technologies,
             commands::ai::ai_provider_status,
             commands::ai::ai_save_provider_key,
             commands::ai::ai_clear_provider_key,

--- a/apps/dataforseo-app/src-tauri/src/ratelimit/scheduler.rs
+++ b/apps/dataforseo-app/src-tauri/src/ratelimit/scheduler.rs
@@ -17,6 +17,7 @@ pub enum Family {
     SerpLive,
     SerpTask,
     Backlinks,
+    DomainAnalytics,
 }
 
 struct Bucket {
@@ -69,6 +70,10 @@ impl Scheduler {
         // capacity model as SerpTask, the per-family Semaphore will be
         // added if we add parallel calls later.
         buckets.insert(Family::Backlinks, Bucket::new(2000.0, 2000.0 / 60.0));
+        // Domain Analytics (whois, technologies): 2000 rpm in DataForSEO's
+        // documented limits. Same capacity model as Backlinks; UI calls
+        // are one-at-a-time so the burst capacity is more than enough.
+        buckets.insert(Family::DomainAnalytics, Bucket::new(2000.0, 2000.0 / 60.0));
         Self { buckets: Mutex::new(buckets) }
     }
 

--- a/apps/dataforseo-app/src/App.tsx
+++ b/apps/dataforseo-app/src/App.tsx
@@ -4,6 +4,7 @@ import AdsPage from "./routes/AdsPage";
 import BacklinksPage from "./routes/BacklinksPage";
 import ChatPage from "./routes/ChatPage";
 import ComparePage from "./routes/ComparePage";
+import DomainAnalyticsPage from "./routes/DomainAnalyticsPage";
 import KeywordsPage from "./routes/KeywordsPage";
 import SerpPage from "./routes/SerpPage";
 import DomainPage from "./routes/DomainPage";
@@ -18,6 +19,7 @@ const navItems = [
   { to: "/serp", label: "SERP" },
   { to: "/domain", label: "Domain" },
   { to: "/backlinks", label: "Backlinks" },
+  { to: "/domain-analytics", label: "Domain Analytics" },
   { to: "/traffic", label: "Traffic" },
   { to: "/ads", label: "Ads" },
   { to: "/social", label: "Social" },
@@ -52,6 +54,7 @@ export default function App() {
           <Route path="/serp/*" element={<SerpPage />} />
           <Route path="/domain/*" element={<DomainPage />} />
           <Route path="/backlinks" element={<BacklinksPage />} />
+          <Route path="/domain-analytics" element={<DomainAnalyticsPage />} />
           <Route path="/traffic" element={<TrafficPage />} />
           <Route path="/ads" element={<AdsPage />} />
           <Route path="/social" element={<SocialPage />} />

--- a/apps/dataforseo-app/src/lib/cost.ts
+++ b/apps/dataforseo-app/src/lib/cost.ts
@@ -16,7 +16,9 @@ export type CostAction =
       depth: number;
       extra_params: number;
     }
-  | { kind: "Backlinks"; target_count: number; rows_per_target: number };
+  | { kind: "Backlinks"; target_count: number; rows_per_target: number }
+  | { kind: "DomainAnalyticsWhois"; rows: number }
+  | { kind: "DomainAnalyticsTechnologies" };
 
 export function estimate(action: CostAction): number {
   switch (action.kind) {
@@ -56,5 +58,9 @@ export function estimate(action: CostAction): number {
         action.target_count * action.rows_per_target * 0.00003
       );
     }
+    case "DomainAnalyticsWhois":
+      return Math.max(1, action.rows) * 0.0001;
+    case "DomainAnalyticsTechnologies":
+      return 0.001;
   }
 }

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -115,6 +115,12 @@ export const tauriApi = {
   backlinksDomainIntersection: (params: BacklinksIntersectionParams) =>
     invoke<BacklinksListView>("backlinks_domain_intersection", { params }),
 
+  whoisOverview: (args: { domain: string }) =>
+    invoke<WhoisView>("whois_overview", args),
+
+  domainTechnologies: (args: { domain: string }) =>
+    invoke<TechnologiesView>("domain_technologies", args),
+
   getRecentCalls: (args: { limit: number }) =>
     invoke<CallLogRow[]>("get_recent_calls", args),
 
@@ -350,6 +356,24 @@ export interface BacklinksIntersectionParams {
   includeSubdomains: boolean;
   filter: FilterTree | null;
   orderBy: string[] | null;
+}
+
+export interface WhoisView {
+  domain: string;
+  // DataForSEO returns ~30 fields per row (registrar, dates, name servers,
+  // status flags, contact info). The page picks the ones it knows.
+  item: Record<string, unknown> | null;
+  cost_usd: number;
+  estimated_usd: number;
+}
+
+export interface TechnologiesView {
+  domain: string;
+  // Whole result blob — has `technologies` map keyed by category, plus
+  // metadata fields (last_visited_date, country_iso_code, etc.).
+  result: Record<string, unknown> | null;
+  cost_usd: number;
+  estimated_usd: number;
 }
 
 export interface TaskBatchId {

--- a/apps/dataforseo-app/src/routes/DomainAnalyticsPage.tsx
+++ b/apps/dataforseo-app/src/routes/DomainAnalyticsPage.tsx
@@ -1,0 +1,375 @@
+import { useMemo, useState } from "react";
+import toast from "react-hot-toast";
+
+import CostPreview from "../components/CostPreview";
+import { type CostAction } from "../lib/cost";
+import { formatUsd } from "../lib/format";
+import {
+  tauriApi,
+  type TechnologiesView,
+  type WhoisView,
+} from "../lib/tauri";
+
+type Tab = "whois" | "technologies";
+
+export default function DomainAnalyticsPage() {
+  const [tab, setTab] = useState<Tab>("whois");
+
+  return (
+    <section className="flex flex-col gap-6">
+      <header>
+        <h2 className="text-xl font-semibold">Domain Analytics</h2>
+        <p className="text-sm text-slate-600">
+          Two cheap one-shot lookups: registrar / WHOIS overview (0.0001 USD)
+          and the tech stack a domain is running (0.001 USD). Useful as a
+          quick prelude to the deeper Backlinks / SERP work.
+        </p>
+      </header>
+
+      <nav className="flex gap-1 border-b text-sm">
+        <TabButton active={tab === "whois"} onClick={() => setTab("whois")}>
+          WHOIS
+        </TabButton>
+        <TabButton
+          active={tab === "technologies"}
+          onClick={() => setTab("technologies")}
+        >
+          Technologies
+        </TabButton>
+      </nav>
+
+      {tab === "whois" ? <WhoisTab /> : <TechnologiesTab />}
+    </section>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`-mb-px border-b-2 px-3 py-2 ${
+        active
+          ? "border-slate-800 text-slate-900"
+          : "border-transparent text-slate-500 hover:text-slate-700"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ---------- WHOIS ----------
+
+function WhoisTab() {
+  const [domain, setDomain] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [view, setView] = useState<WhoisView | null>(null);
+
+  async function onRun() {
+    const trimmed = domain.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    try {
+      const result = await tauriApi.whoisOverview({ domain: trimmed });
+      setView(result);
+      toast.success(`Loaded WHOIS for ${trimmed} (${formatUsd(result.cost_usd)})`);
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Inputs
+        domain={domain}
+        setDomain={setDomain}
+        busy={busy}
+        onRun={onRun}
+        runLabel="Lookup WHOIS"
+        cost={{ kind: "DomainAnalyticsWhois", rows: 1 }}
+        details={["Single-domain lookup", "0.0001 USD per row"]}
+      />
+
+      {view && view.item ? (
+        <WhoisResult view={view} />
+      ) : view ? (
+        <div className="rounded border bg-white p-6 text-center text-sm text-slate-500">
+          No WHOIS data returned for {view.domain} (unregistered or
+          privacy-shielded).
+        </div>
+      ) : (
+        !busy && (
+          <div className="rounded border bg-white p-8 text-center text-sm text-slate-500">
+            Enter a domain to look up its WHOIS record.
+          </div>
+        )
+      )}
+    </div>
+  );
+}
+
+function WhoisResult({ view }: { view: WhoisView }) {
+  const item = view.item ?? {};
+  const get = (k: string): string | null => {
+    const v = (item as Record<string, unknown>)[k];
+    if (typeof v === "string") return v;
+    if (typeof v === "number") return String(v);
+    return null;
+  };
+  const arr = (k: string): string[] => {
+    const v = (item as Record<string, unknown>)[k];
+    if (!Array.isArray(v)) return [];
+    return v.filter((x): x is string => typeof x === "string");
+  };
+  const dateOnly = (k: string) => {
+    const s = get(k);
+    return s ? s.slice(0, 10) : null;
+  };
+
+  const tiles: Array<{ label: string; value: string | null }> = [
+    { label: "Registrar", value: get("registrar") },
+    { label: "Created", value: dateOnly("created_datetime") },
+    { label: "Updated", value: dateOnly("changed_datetime") },
+    { label: "Expires", value: dateOnly("expiration_datetime") },
+    { label: "Registrar IANA ID", value: get("registrar_iana_id") },
+    { label: "Country", value: get("country_iso_code") },
+  ];
+
+  const nameServers = arr("name_servers");
+  const status = arr("status");
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+        <strong className="font-mono text-slate-700">{view.domain}</strong>
+        <span className="ml-auto">
+          actual {formatUsd(view.cost_usd)} · estimated{" "}
+          {formatUsd(view.estimated_usd)}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+        {tiles.map((t) => (
+          <div key={t.label} className="rounded border bg-white p-3">
+            <div className="text-xs text-slate-500">{t.label}</div>
+            <div className="mt-1 text-sm font-semibold">{t.value ?? "—"}</div>
+          </div>
+        ))}
+      </div>
+
+      {nameServers.length > 0 && (
+        <div className="rounded border bg-white p-3">
+          <div className="text-xs text-slate-500">Name servers</div>
+          <ul className="mt-1 list-disc pl-5 text-sm font-mono">
+            {nameServers.map((ns) => (
+              <li key={ns}>{ns}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {status.length > 0 && (
+        <div className="rounded border bg-white p-3">
+          <div className="text-xs text-slate-500">Status flags</div>
+          <div className="mt-1 flex flex-wrap gap-1">
+            {status.map((s) => (
+              <span
+                key={s}
+                className="rounded bg-slate-100 px-2 py-0.5 text-xs font-mono"
+              >
+                {s}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <details className="rounded border bg-slate-50 p-3 text-xs">
+        <summary className="cursor-pointer font-medium text-slate-700">
+          Raw response (debug)
+        </summary>
+        <pre className="mt-2 overflow-x-auto text-[11px]">
+          {JSON.stringify(view.item, null, 2)}
+        </pre>
+      </details>
+    </div>
+  );
+}
+
+// ---------- Technologies ----------
+
+function TechnologiesTab() {
+  const [domain, setDomain] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [view, setView] = useState<TechnologiesView | null>(null);
+
+  async function onRun() {
+    const trimmed = domain.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    try {
+      const result = await tauriApi.domainTechnologies({ domain: trimmed });
+      setView(result);
+      toast.success(
+        `Loaded tech stack for ${trimmed} (${formatUsd(result.cost_usd)})`,
+      );
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Inputs
+        domain={domain}
+        setDomain={setDomain}
+        busy={busy}
+        onRun={onRun}
+        runLabel="Detect technologies"
+        cost={{ kind: "DomainAnalyticsTechnologies" }}
+        details={["Single request, flat fee", "Returns tech stack by category"]}
+      />
+
+      {view ? (
+        <TechnologiesResult view={view} />
+      ) : (
+        !busy && (
+          <div className="rounded border bg-white p-8 text-center text-sm text-slate-500">
+            Enter a domain to detect its technology stack.
+          </div>
+        )
+      )}
+    </div>
+  );
+}
+
+function TechnologiesResult({ view }: { view: TechnologiesView }) {
+  // result.technologies is a map keyed by category → object whose values
+  // are arrays of tech names. We flatten it to {category, names[]}.
+  const groups = useMemo(() => {
+    const tech = (view.result as Record<string, unknown> | null)?.[
+      "technologies"
+    ];
+    if (!tech || typeof tech !== "object") return [];
+    return Object.entries(tech as Record<string, unknown>)
+      .map(([category, sub]) => {
+        const names: string[] = [];
+        if (sub && typeof sub === "object") {
+          for (const value of Object.values(sub as Record<string, unknown>)) {
+            if (Array.isArray(value)) {
+              for (const n of value) {
+                if (typeof n === "string") names.push(n);
+              }
+            }
+          }
+        }
+        return { category, names: Array.from(new Set(names)).sort() };
+      })
+      .filter((g) => g.names.length > 0)
+      .sort((a, b) => a.category.localeCompare(b.category));
+  }, [view]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+        <strong className="font-mono text-slate-700">{view.domain}</strong>
+        <span className="ml-auto">
+          actual {formatUsd(view.cost_usd)} · estimated{" "}
+          {formatUsd(view.estimated_usd)}
+        </span>
+      </div>
+
+      {groups.length === 0 ? (
+        <div className="rounded border bg-white p-6 text-center text-sm text-slate-500">
+          No technologies detected for {view.domain}.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+          {groups.map((g) => (
+            <div key={g.category} className="rounded border bg-white p-3">
+              <div className="text-xs uppercase tracking-wide text-slate-500">
+                {g.category.replace(/_/g, " ")}
+              </div>
+              <div className="mt-2 flex flex-wrap gap-1">
+                {g.names.map((n) => (
+                  <span
+                    key={n}
+                    className="rounded bg-slate-100 px-2 py-0.5 text-xs"
+                  >
+                    {n}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <details className="rounded border bg-slate-50 p-3 text-xs">
+        <summary className="cursor-pointer font-medium text-slate-700">
+          Raw response (debug)
+        </summary>
+        <pre className="mt-2 max-h-96 overflow-auto text-[11px]">
+          {JSON.stringify(view.result, null, 2)}
+        </pre>
+      </details>
+    </div>
+  );
+}
+
+// ---------- Shared inputs (small enough that copying it once into each
+// tab would have been fine, but the page reads cleaner with a single
+// definition since both tabs have identical input layout) ----------
+
+function Inputs(props: {
+  domain: string;
+  setDomain: (v: string) => void;
+  busy: boolean;
+  onRun: () => void;
+  runLabel: string;
+  cost: CostAction;
+  details: string[];
+}) {
+  const { domain, setDomain, busy, onRun, runLabel, cost, details } = props;
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_320px]">
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium text-slate-700">Domain</span>
+        <input
+          type="text"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          disabled={busy}
+          className="rounded border px-2 py-1 font-mono text-sm disabled:bg-slate-50"
+          placeholder="example.com"
+          spellCheck={false}
+          autoComplete="off"
+        />
+      </label>
+      <div className="flex flex-col gap-3">
+        <CostPreview action={cost} details={details} disabled={busy || !domain.trim()} />
+        <button
+          type="button"
+          onClick={onRun}
+          disabled={busy || !domain.trim()}
+          className="rounded bg-slate-800 px-3 py-2 text-sm text-white disabled:opacity-50"
+        >
+          {busy ? "Loading…" : runLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/dataforseo-app/src/routes/DomainAnalyticsPage.tsx
+++ b/apps/dataforseo-app/src/routes/DomainAnalyticsPage.tsx
@@ -258,7 +258,8 @@ function TechnologiesTab() {
 
 function TechnologiesResult({ view }: { view: TechnologiesView }) {
   // result.technologies is a map keyed by category → object whose values
-  // are arrays of tech names. We flatten it to {category, names[]}.
+  // are arrays of tech names. Flatten to {category, names[]} via
+  // flatMap on the inner values, then dedupe + sort each category.
   const groups = useMemo(() => {
     const tech = (view.result as Record<string, unknown> | null)?.[
       "technologies"
@@ -266,16 +267,11 @@ function TechnologiesResult({ view }: { view: TechnologiesView }) {
     if (!tech || typeof tech !== "object") return [];
     return Object.entries(tech as Record<string, unknown>)
       .map(([category, sub]) => {
-        const names: string[] = [];
-        if (sub && typeof sub === "object") {
-          for (const value of Object.values(sub as Record<string, unknown>)) {
-            if (Array.isArray(value)) {
-              for (const n of value) {
-                if (typeof n === "string") names.push(n);
-              }
-            }
-          }
-        }
+        const names = Object.values(
+          (sub && typeof sub === "object" ? sub : {}) as Record<string, unknown>,
+        )
+          .flatMap((v) => (Array.isArray(v) ? v : []))
+          .filter((n): n is string => typeof n === "string");
         return { category, names: Array.from(new Set(names)).sort() };
       })
       .filter((g) => g.names.length > 0)


### PR DESCRIPTION
Stacked on #40. Picks up the next item from the catalogue's roadmap (Domain Analytics · whois + technologies).

## Summary

Two cheap one-shot lookups, new sidebar entry, demonstrates the "any new family slots in" pattern beyond Backlinks.

### Backend

- `ratelimit::Family::DomainAnalytics` added with the 2000 rpm bucket.
- `domain::cost`: two new variants
  - `DomainAnalyticsWhois { rows }` — 0.0001 USD per row
  - `DomainAnalyticsTechnologies` — flat 0.001 USD per request
  Three unit tests cover the row baseline, the `.max(1.0)` guard against pre-keystroke 0 estimates, and the flat-fee branch.
- `domain::endpoints` adds two constants so the ledger surfaces them with stable names.
- `api/domain_analytics.rs`: `whois_overview_live` (single-domain WHOIS with registrar, expiry, name servers, status flags) and `domain_technologies_live` (Wappalyzer-style tech stack).
- `commands/domain_analytics.rs`: two tauri commands going through `run_with_ledger` so calls show up in `/usage`. WHOIS pulls the first array item server-side so the frontend gets a flat shape; technologies passes the whole result blob through since the UI groups by category.

### Frontend

- New **DomainAnalyticsPage** with two tabs: **WHOIS** and **Technologies**. WHOIS renders six metadata tiles (registrar, dates, IANA ID, country) plus name-server and status-flag panels. Technologies flattens DataForSEO's nested category map into one chip cluster per category.
- `src/lib/cost.ts` mirrors the two new `CostAction` variants so the `CostPreview` updates without a Tauri round-trip.
- `App.tsx` adds the new "Domain Analytics" sidebar entry between Backlinks and Traffic, plus the matching route.
- `DATAFORSEO_API_ENDPOINTS.md`: WHOIS and Technologies switched from 🟡 next to ✅ done.

## Test plan

- [ ] `cargo test -p dataforseo-app` — three new cost tests pass
- [ ] `cargo build` — new commands compile, family + endpoint constants registered
- [ ] In the running app, click "Domain Analytics" in the sidebar
- [ ] WHOIS tab on `cloudflare.com` — verify registrar / dates / name-servers populate
- [ ] WHOIS tab on `definitely-not-a-real-domain-12345.invalid` — verify the empty-state message renders
- [ ] Technologies tab on `react.dev` — verify chip clusters render by category
- [ ] Confirm `/usage` shows `domain_analytics.whois.overview` (~0.0001 USD) and `domain_analytics.technologies.domain` (~0.001 USD) rows


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_