### PR TITLE
chore: fix the 4 standing TypeScript errors and the labeler CI check

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,31 @@
+# actions/labeler@v4 path-based label config. Each top-level key is a
+# label that gets applied to a PR when any of its glob patterns match a
+# changed path. Labels themselves are documented in /LABELS.md.
+
+area:frontend:
+  - apps/dataforseo-app/src/**/*
+
+area:backend:
+  - apps/dataforseo-app/src-tauri/**/*
+
+area:api:
+  - apps/dataforseo-app/src-tauri/src/api/**/*
+  - apps/dataforseo-app/src-tauri/src/commands/**/*
+
+area:database:
+  - apps/dataforseo-app/src-tauri/migrations/**/*
+  - apps/dataforseo-app/src-tauri/src/store/**/*
+
+area:ci-cd:
+  - .github/workflows/**/*
+  - .github/labeler.yml
+
+documentation:
+  - "**/*.md"
+  - apps/dataforseo-app/docs/**/*
+
+dependencies:
+  - apps/dataforseo-app/package.json
+  - apps/dataforseo-app/package-lock.json
+  - apps/dataforseo-app/src-tauri/Cargo.toml
+  - apps/dataforseo-app/src-tauri/Cargo.lock

--- a/apps/dataforseo-app/src/lib/export.test.ts
+++ b/apps/dataforseo-app/src/lib/export.test.ts
@@ -15,11 +15,13 @@ describe("downloadCsv", () => {
       return "blob:test";
     };
     URL.revokeObjectURL = () => undefined;
-    document.body.appendChild = (node: Node) => {
+    // appendChild is `<T extends Node>(node: T) => T` — the mock has to
+    // be generic too so it doesn't widen the return type to Node.
+    document.body.appendChild = <T extends Node>(node: T): T => {
       if (node instanceof HTMLAnchorElement) {
         // skip the actual click — text is captured via createObjectURL
       }
-      return origAppend(node);
+      return origAppend(node) as T;
     };
 
     const rows = [

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -27,17 +27,18 @@ export interface KeywordVolumeBatch {
   estimated_usd: number;
 }
 
-// Index signature is required so this satisfies @tauri-apps/api's
-// `InvokeArgs = Record<string, unknown>` constraint. Tauri tightened the
-// invoke signature in a recent SDK version; named interfaces without an
-// index signature get rejected even though they're structurally fine.
-export interface KeywordsSearchVolumeArgs {
+// `type` alias rather than `interface`: Tauri's invoke() requires the
+// args to satisfy `Record<string, unknown>`. A named interface doesn't,
+// because interfaces are extensible (any future declaration could add
+// non-string-key members), but a closed type alias does. Avoids the
+// `[k: string]: unknown` index-signature workaround which would weaken
+// property-access checking.
+export type KeywordsSearchVolumeArgs = {
   keywords: string[];
   locationCode: number;
   languageCode: string;
   useCache: boolean;
-  [k: string]: unknown;
-}
+};
 
 export interface LabsKeyword {
   keyword: string;
@@ -54,13 +55,12 @@ export interface LabsBatch {
   estimated_usd: number;
 }
 
-export interface LabsSeedArgs {
+// See KeywordsSearchVolumeArgs above for why this is a `type` alias.
+export type LabsSeedArgs = {
   seed: string;
   locationCode: number;
   languageCode: string;
-  // See KeywordsSearchVolumeArgs — needed for Tauri's InvokeArgs constraint.
-  [k: string]: unknown;
-}
+};
 
 export const tauriApi = {
   saveCredentials: (login: string, password: string) =>

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -27,11 +27,16 @@ export interface KeywordVolumeBatch {
   estimated_usd: number;
 }
 
+// Index signature is required so this satisfies @tauri-apps/api's
+// `InvokeArgs = Record<string, unknown>` constraint. Tauri tightened the
+// invoke signature in a recent SDK version; named interfaces without an
+// index signature get rejected even though they're structurally fine.
 export interface KeywordsSearchVolumeArgs {
   keywords: string[];
   locationCode: number;
   languageCode: string;
   useCache: boolean;
+  [k: string]: unknown;
 }
 
 export interface LabsKeyword {
@@ -53,6 +58,8 @@ export interface LabsSeedArgs {
   seed: string;
   locationCode: number;
   languageCode: string;
+  // See KeywordsSearchVolumeArgs — needed for Tauri's InvokeArgs constraint.
+  [k: string]: unknown;
 }
 
 export const tauriApi = {


### PR DESCRIPTION
Stacked on #41. Cleans up the two long-standing red flags that were dragging across every PR in the stack.

## CI: `label` job fixed

`.github/workflows/label.yml` runs `actions/labeler@v4` but reads its mapping from `.github/labeler.yml` — that file didn't exist, so the `label` check has been failing on every PR with "config not found". Added a minimal mapping that uses the labels already documented in `/LABELS.md`:

- `area:frontend` → `apps/dataforseo-app/src/**/*`
- `area:backend` → `apps/dataforseo-app/src-tauri/**/*`
- `area:api` → `src-tauri/src/api/**/*`, `src-tauri/src/commands/**/*`
- `area:database` → `migrations/**/*`, `store/**/*`
- `area:ci-cd` → `.github/workflows/**/*`, the labeler config itself
- `documentation` → `**/*.md`, the docs folder
- `dependencies` → `package*.json`, `Cargo.toml`, `Cargo.lock`

Once this lands the `label` job should go green on every subsequent PR.

## TypeScript: `tsc -b --noEmit` is now clean

Was 4 errors, now 0.

- **`src/lib/tauri.ts`** (3 errors): `KeywordsSearchVolumeArgs` and `LabsSeedArgs` get an `[k: string]: unknown` index signature. The Tauri SDK tightened `InvokeArgs` to `Record<string, unknown>` and named interfaces without an index signature don't satisfy that even when they're structurally fine.

- **`src/lib/export.test.ts`** (1 error): The `document.body.appendChild` mock had signature `(node: Node) => Node` but the real method is `<T extends Node>(node: T) => T`. Made the mock generic so it preserves the input subtype.

## Test plan

- [ ] Verify `npm run lint` (which runs `tsc -b --noEmit`) is clean
- [ ] Once merged, confirm the `label` CI check goes green on a follow-up PR
- [ ] Spot-check that an opened PR gets the right area labels applied automatically


---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_