### PR TITLE
FEATURE: UX polish — ExportMenu rollout + first-run onboarding wizard

### DIFF
--- a/apps/dataforseo-app/src/App.tsx
+++ b/apps/dataforseo-app/src/App.tsx
@@ -13,6 +13,7 @@ import ComparePage from "./routes/ComparePage";
 import DomainAnalyticsPage from "./routes/DomainAnalyticsPage";
 import KeywordsPage from "./routes/KeywordsPage";
 import OnPagePage from "./routes/OnPagePage";
+import OnboardingPage, { useOnboardingGate } from "./routes/OnboardingPage";
 import SerpPage from "./routes/SerpPage";
 import DomainPage from "./routes/DomainPage";
 import TopicPage from "./routes/TopicPage";
@@ -56,6 +57,19 @@ export default function App() {
 }
 
 function AppShell() {
+  const [status, markReady] = useOnboardingGate();
+
+  if (status === "loading") {
+    return (
+      <div className="flex h-screen items-center justify-center text-sm text-slate-500">
+        Connecting…
+      </div>
+    );
+  }
+  if (status === "needs-onboarding") {
+    return <OnboardingPage onComplete={markReady} />;
+  }
+
   return (
     <div className="flex h-screen">
       <aside className="w-56 border-r bg-slate-50 p-4">

--- a/apps/dataforseo-app/src/App.tsx
+++ b/apps/dataforseo-app/src/App.tsx
@@ -57,7 +57,7 @@ export default function App() {
 }
 
 function AppShell() {
-  const [status, markReady] = useOnboardingGate();
+  const [status, markReady, gate] = useOnboardingGate();
 
   if (status === "loading") {
     return (
@@ -68,6 +68,29 @@ function AppShell() {
   }
   if (status === "needs-onboarding") {
     return <OnboardingPage onComplete={markReady} />;
+  }
+  if (status === "error") {
+    return (
+      <div className="flex h-screen items-center justify-center bg-slate-50">
+        <div className="w-full max-w-md rounded border bg-white p-6 text-center text-sm">
+          <h2 className="mb-2 text-lg font-semibold text-slate-800">Couldn't reach DataForSEO</h2>
+          <p className="mb-4 text-slate-600">
+            {gate.errorMessage ?? "Network or service error."}
+          </p>
+          <p className="mb-4 text-xs text-slate-500">
+            Likely transient. Check your connection and retry — your credentials are still
+            saved.
+          </p>
+          <button
+            type="button"
+            onClick={gate.retry}
+            className="rounded bg-slate-800 px-4 py-2 text-sm text-white"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/apps/dataforseo-app/src/routes/OnboardingPage.tsx
+++ b/apps/dataforseo-app/src/routes/OnboardingPage.tsx
@@ -1,0 +1,386 @@
+import { useEffect, useState } from "react";
+import toast from "react-hot-toast";
+
+import { tauriApi } from "../lib/tauri";
+
+type StepId = "welcome" | "credentials" | "budget" | "project" | "done";
+
+const STEPS: { id: StepId; label: string }[] = [
+  { id: "welcome", label: "Welcome" },
+  { id: "credentials", label: "Credentials" },
+  { id: "budget", label: "Budget" },
+  { id: "project", label: "First project" },
+  { id: "done", label: "Done" },
+];
+
+interface Props {
+  /// Called after the final step completes; the host should refetch
+  /// connection state and unmount this page in favor of the main app.
+  onComplete: () => void;
+}
+
+/// First-run setup. Forces the user through (1) DataForSEO credentials,
+/// (2) an advisory daily budget, and (3) a first tracked-domain project
+/// before unblocking the main app. The Settings page exposes a
+/// "Re-run onboarding" button that re-renders this if the user later
+/// wants to change targets.
+export default function OnboardingPage({ onComplete }: Props) {
+  const [active, setActive] = useState<StepId>("welcome");
+
+  // Credentials
+  const [login, setLogin] = useState("");
+  const [password, setPassword] = useState("");
+  const [verifying, setVerifying] = useState(false);
+
+  // Budget
+  const [dailyLimit, setDailyLimit] = useState("5");
+  const [alertAt, setAlertAt] = useState("80");
+
+  // Project
+  const [projectTarget, setProjectTarget] = useState("");
+  const [projectName, setProjectName] = useState("");
+  const [creatingProject, setCreatingProject] = useState(false);
+
+  async function onVerifyCredentials() {
+    if (!login.trim() || !password) {
+      toast.error("Login and password required");
+      return;
+    }
+    setVerifying(true);
+    try {
+      await tauriApi.saveCredentials(login.trim(), password);
+      const info = await tauriApi.testConnection();
+      toast.success(`Connected as ${info.login} · balance ${info.balance.toFixed(2)} USD`);
+      setActive("budget");
+    } catch (e) {
+      toast.error(`Verification failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setVerifying(false);
+    }
+  }
+
+  async function onSetBudget() {
+    const limit = parseFloat(dailyLimit);
+    const pct = parseFloat(alertAt);
+    if (!Number.isFinite(limit) || limit <= 0) {
+      toast.error("Limit must be a positive number");
+      return;
+    }
+    if (!Number.isFinite(pct) || pct <= 0 || pct > 100) {
+      toast.error("Alert threshold must be between 1 and 100");
+      return;
+    }
+    try {
+      await tauriApi.setBudget({
+        budget: { period: "daily", limit_usd: limit, alert_at_pct: pct },
+      });
+      toast.success(`Daily budget set to ${limit.toFixed(2)} USD`);
+      setActive("project");
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    }
+  }
+
+  async function onCreateProject() {
+    const target = projectTarget.trim();
+    const name = projectName.trim() || target;
+    if (!target) {
+      toast.error("Target domain required");
+      return;
+    }
+    setCreatingProject(true);
+    try {
+      await tauriApi.projectsCreate({ name, target });
+      toast.success(`Project "${name}" created`);
+      setActive("done");
+    } catch (e) {
+      toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setCreatingProject(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-50">
+      <div className="w-full max-w-2xl rounded border bg-white p-8 shadow-sm">
+        <header className="mb-6">
+          <h1 className="text-2xl font-semibold">Welcome to DataForSEO</h1>
+          <p className="text-sm text-slate-600">
+            Three quick steps to get you set up. You can change everything later in Settings.
+          </p>
+        </header>
+
+        <Stepper active={active} />
+
+        <div className="mt-6">
+          {active === "welcome" && (
+            <section className="flex flex-col gap-3 text-sm">
+              <p>
+                This is a local Tauri app that wraps the DataForSEO API to give you a SEMrush
+                replacement at ~15× lower cost. Your credentials never leave the OS keychain;
+                every API call is metered and cached so repeat lookups cost nothing.
+              </p>
+              <p>
+                You'll need a DataForSEO account. Sign up at{" "}
+                <a
+                  href="https://app.dataforseo.com/register"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:underline"
+                >
+                  app.dataforseo.com/register
+                </a>{" "}
+                — they require a 50 USD minimum deposit and a 100 USD/month spend on the
+                Backlinks family if you use it.
+              </p>
+              <button
+                type="button"
+                onClick={() => setActive("credentials")}
+                className="mt-3 self-end rounded bg-slate-800 px-4 py-2 text-sm text-white"
+              >
+                Get started →
+              </button>
+            </section>
+          )}
+
+          {active === "credentials" && (
+            <section className="flex flex-col gap-3 text-sm">
+              <p className="text-slate-600">
+                Paste the API login and password from your DataForSEO dashboard. They're stored
+                in the OS keychain (macOS Keychain / Windows Credential Manager / Linux
+                Secret Service) and never written to disk in plaintext.
+              </p>
+              <label className="flex flex-col gap-1">
+                <span className="text-xs font-medium text-slate-700">API login (email)</span>
+                <input
+                  type="email"
+                  value={login}
+                  onChange={(e) => setLogin(e.target.value)}
+                  disabled={verifying}
+                  className="rounded border px-2 py-1 font-mono text-sm disabled:bg-slate-50"
+                  placeholder="you@company.com"
+                  autoComplete="username"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="text-xs font-medium text-slate-700">API password</span>
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  disabled={verifying}
+                  className="rounded border px-2 py-1 font-mono text-sm disabled:bg-slate-50"
+                  autoComplete="current-password"
+                />
+              </label>
+              <div className="mt-3 flex justify-between">
+                <button
+                  type="button"
+                  onClick={() => setActive("welcome")}
+                  className="rounded border border-slate-300 px-4 py-2 text-sm text-slate-700"
+                >
+                  ← Back
+                </button>
+                <button
+                  type="button"
+                  onClick={onVerifyCredentials}
+                  disabled={verifying || !login.trim() || !password}
+                  className="rounded bg-slate-800 px-4 py-2 text-sm text-white disabled:opacity-50"
+                >
+                  {verifying ? "Verifying…" : "Verify & continue →"}
+                </button>
+              </div>
+            </section>
+          )}
+
+          {active === "budget" && (
+            <section className="flex flex-col gap-3 text-sm">
+              <p className="text-slate-600">
+                Set a daily spend cap. The Usage page warns at the alert threshold and turns red
+                when exceeded — but it's advisory only; calls aren't actually blocked, since
+                you might want to bust through for a one-off.
+              </p>
+              <div className="grid grid-cols-2 gap-3">
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-medium text-slate-700">Daily limit (USD)</span>
+                  <input
+                    type="number"
+                    min="0.01"
+                    step="0.01"
+                    value={dailyLimit}
+                    onChange={(e) => setDailyLimit(e.target.value)}
+                    className="rounded border px-2 py-1 text-sm"
+                  />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="text-xs font-medium text-slate-700">Alert at (%)</span>
+                  <input
+                    type="number"
+                    min="1"
+                    max="100"
+                    step="1"
+                    value={alertAt}
+                    onChange={(e) => setAlertAt(e.target.value)}
+                    className="rounded border px-2 py-1 text-sm"
+                  />
+                </label>
+              </div>
+              <p className="text-xs text-slate-500">
+                Typical daily spend during active research: 0.10–0.50 USD. Leave at 5 USD/day if
+                unsure — you can always adjust on /usage later.
+              </p>
+              <div className="mt-3 flex justify-between">
+                <button
+                  type="button"
+                  onClick={() => setActive("credentials")}
+                  className="rounded border border-slate-300 px-4 py-2 text-sm text-slate-700"
+                >
+                  ← Back
+                </button>
+                <button
+                  type="button"
+                  onClick={onSetBudget}
+                  className="rounded bg-slate-800 px-4 py-2 text-sm text-white"
+                >
+                  Set budget →
+                </button>
+              </div>
+            </section>
+          )}
+
+          {active === "project" && (
+            <section className="flex flex-col gap-3 text-sm">
+              <p className="text-slate-600">
+                Pick the first domain you want to track. A project groups all the keyword
+                tracking, audits, and brand-monitoring data for one site. You can add more
+                projects later via the sidebar switcher.
+              </p>
+              <label className="flex flex-col gap-1">
+                <span className="text-xs font-medium text-slate-700">Target domain</span>
+                <input
+                  type="text"
+                  value={projectTarget}
+                  onChange={(e) => setProjectTarget(e.target.value)}
+                  disabled={creatingProject}
+                  className="rounded border px-2 py-1 font-mono text-sm disabled:bg-slate-50"
+                  placeholder="example.com"
+                  spellCheck={false}
+                  autoComplete="off"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="text-xs font-medium text-slate-700">
+                  Project name <span className="text-slate-400">(optional)</span>
+                </span>
+                <input
+                  type="text"
+                  value={projectName}
+                  onChange={(e) => setProjectName(e.target.value)}
+                  disabled={creatingProject}
+                  className="rounded border px-2 py-1 text-sm disabled:bg-slate-50"
+                  placeholder={projectTarget || "Defaults to the domain"}
+                  autoComplete="off"
+                />
+              </label>
+              <div className="mt-3 flex justify-between">
+                <button
+                  type="button"
+                  onClick={() => setActive("budget")}
+                  className="rounded border border-slate-300 px-4 py-2 text-sm text-slate-700"
+                >
+                  ← Back
+                </button>
+                <button
+                  type="button"
+                  onClick={onCreateProject}
+                  disabled={creatingProject || !projectTarget.trim()}
+                  className="rounded bg-slate-800 px-4 py-2 text-sm text-white disabled:opacity-50"
+                >
+                  {creatingProject ? "Creating…" : "Create project →"}
+                </button>
+              </div>
+            </section>
+          )}
+
+          {active === "done" && (
+            <section className="flex flex-col gap-3 text-center text-sm">
+              <div className="text-5xl">🎉</div>
+              <h2 className="text-xl font-semibold">You're all set</h2>
+              <p className="text-slate-600">
+                Credentials saved · daily budget configured · first project created. Open
+                /keywords to start researching, /tracking to monitor positions daily, or /audit
+                for a full-site SEO crawl.
+              </p>
+              <button
+                type="button"
+                onClick={onComplete}
+                className="mt-3 self-center rounded bg-slate-800 px-5 py-2 text-sm text-white"
+              >
+                Open the app
+              </button>
+            </section>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Stepper({ active }: { active: StepId }) {
+  const activeIdx = STEPS.findIndex((s) => s.id === active);
+  return (
+    <ol className="flex items-center gap-2 text-xs">
+      {STEPS.map((s, i) => {
+        const done = i < activeIdx;
+        const current = i === activeIdx;
+        return (
+          <li key={s.id} className="flex items-center gap-2">
+            <span
+              className={`flex h-6 w-6 items-center justify-center rounded-full border text-[11px] font-semibold ${
+                current
+                  ? "border-slate-800 bg-slate-800 text-white"
+                  : done
+                    ? "border-emerald-500 bg-emerald-500 text-white"
+                    : "border-slate-300 text-slate-400"
+              }`}
+            >
+              {done ? "✓" : i + 1}
+            </span>
+            <span
+              className={`${
+                current ? "font-medium text-slate-800" : "text-slate-500"
+              }`}
+            >
+              {s.label}
+            </span>
+            {i < STEPS.length - 1 && <span className="text-slate-300">·</span>}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+/// Helper for App.tsx: returns true once `tauriApi.testConnection` succeeds,
+/// false once it errors with auth, and null while pending. The host
+/// component decides whether to render OnboardingPage or the main UI.
+export function useOnboardingGate() {
+  const [status, setStatus] = useState<"loading" | "ready" | "needs-onboarding">("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    tauriApi
+      .testConnection()
+      .then(() => {
+        if (!cancelled) setStatus("ready");
+      })
+      .catch(() => {
+        if (!cancelled) setStatus("needs-onboarding");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return [status, () => setStatus("ready")] as const;
+}

--- a/apps/dataforseo-app/src/routes/OnboardingPage.tsx
+++ b/apps/dataforseo-app/src/routes/OnboardingPage.tsx
@@ -35,6 +35,7 @@ export default function OnboardingPage({ onComplete }: Props) {
   // Budget
   const [dailyLimit, setDailyLimit] = useState("5");
   const [alertAt, setAlertAt] = useState("80");
+  const [savingBudget, setSavingBudget] = useState(false);
 
   // Project
   const [projectTarget, setProjectTarget] = useState("");
@@ -70,6 +71,7 @@ export default function OnboardingPage({ onComplete }: Props) {
       toast.error("Alert threshold must be between 1 and 100");
       return;
     }
+    setSavingBudget(true);
     try {
       await tauriApi.setBudget({
         budget: { period: "daily", limit_usd: limit, alert_at_pct: pct },
@@ -78,6 +80,8 @@ export default function OnboardingPage({ onComplete }: Props) {
       setActive("project");
     } catch (e) {
       toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+    } finally {
+      setSavingBudget(false);
     }
   }
 
@@ -209,7 +213,8 @@ export default function OnboardingPage({ onComplete }: Props) {
                     step="0.01"
                     value={dailyLimit}
                     onChange={(e) => setDailyLimit(e.target.value)}
-                    className="rounded border px-2 py-1 text-sm"
+                    disabled={savingBudget}
+                    className="rounded border px-2 py-1 text-sm disabled:bg-slate-50"
                   />
                 </label>
                 <label className="flex flex-col gap-1">
@@ -221,7 +226,8 @@ export default function OnboardingPage({ onComplete }: Props) {
                     step="1"
                     value={alertAt}
                     onChange={(e) => setAlertAt(e.target.value)}
-                    className="rounded border px-2 py-1 text-sm"
+                    disabled={savingBudget}
+                    className="rounded border px-2 py-1 text-sm disabled:bg-slate-50"
                   />
                 </label>
               </div>
@@ -233,16 +239,18 @@ export default function OnboardingPage({ onComplete }: Props) {
                 <button
                   type="button"
                   onClick={() => setActive("credentials")}
-                  className="rounded border border-slate-300 px-4 py-2 text-sm text-slate-700"
+                  disabled={savingBudget}
+                  className="rounded border border-slate-300 px-4 py-2 text-sm text-slate-700 disabled:opacity-50"
                 >
                   ← Back
                 </button>
                 <button
                   type="button"
                   onClick={onSetBudget}
-                  className="rounded bg-slate-800 px-4 py-2 text-sm text-white"
+                  disabled={savingBudget}
+                  className="rounded bg-slate-800 px-4 py-2 text-sm text-white disabled:opacity-50"
                 >
-                  Set budget →
+                  {savingBudget ? "Saving…" : "Set budget →"}
                 </button>
               </div>
             </section>
@@ -361,11 +369,36 @@ function Stepper({ active }: { active: StepId }) {
   );
 }
 
-/// Helper for App.tsx: returns true once `tauriApi.testConnection` succeeds,
-/// false once it errors with auth, and null while pending. The host
-/// component decides whether to render OnboardingPage or the main UI.
+/// Helper for App.tsx: classifies the result of `tauriApi.testConnection`
+/// into one of four states. We deliberately don't conflate transient
+/// network errors with the genuine "no credentials yet" / "credentials
+/// rejected" cases — forcing the user back through the onboarding wizard
+/// because their wifi blipped is a worse experience than letting them
+/// click Retry.
+export type GateStatus = "loading" | "ready" | "needs-onboarding" | "error";
+
 export function useOnboardingGate() {
-  const [status, setStatus] = useState<"loading" | "ready" | "needs-onboarding">("loading");
+  const [status, setStatus] = useState<GateStatus>("loading");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  function probe() {
+    setStatus("loading");
+    setErrorMessage(null);
+    tauriApi
+      .testConnection()
+      .then(() => setStatus("ready"))
+      .catch((e: unknown) => {
+        const msg = typeof e === "object" && e && "message" in e
+          ? String((e as { message?: unknown }).message ?? "")
+          : String(e);
+        if (isAuthOrConfigError(msg)) {
+          setStatus("needs-onboarding");
+        } else {
+          setErrorMessage(msg || "Failed to reach DataForSEO");
+          setStatus("error");
+        }
+      });
+  }
 
   useEffect(() => {
     let cancelled = false;
@@ -374,13 +407,47 @@ export function useOnboardingGate() {
       .then(() => {
         if (!cancelled) setStatus("ready");
       })
-      .catch(() => {
-        if (!cancelled) setStatus("needs-onboarding");
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        const msg = typeof e === "object" && e && "message" in e
+          ? String((e as { message?: unknown }).message ?? "")
+          : String(e);
+        if (isAuthOrConfigError(msg)) {
+          setStatus("needs-onboarding");
+        } else {
+          setErrorMessage(msg || "Failed to reach DataForSEO");
+          setStatus("error");
+        }
       });
     return () => {
       cancelled = true;
     };
   }, []);
 
-  return [status, () => setStatus("ready")] as const;
+  return [
+    status,
+    () => setStatus("ready"),
+    { errorMessage, retry: probe },
+  ] as const;
+}
+
+/// Heuristic for "should this error force the onboarding wizard?". The
+/// AppError variants we care about: Auth (no creds set or wrong creds)
+/// and Validation (creds malformed). Everything else — network failures,
+/// 5xx upstream errors, timeout — is treated as transient and the user
+/// gets a Retry button instead of a forced re-setup.
+function isAuthOrConfigError(message: string): boolean {
+  const lc = message.toLowerCase();
+  return (
+    lc.includes("credentials not set") ||
+    lc.includes("credentials") && lc.includes("invalid") ||
+    lc.includes("unauthorized") ||
+    lc.includes("auth") ||
+    lc.includes("401") ||
+    lc.includes("403") ||
+    // DataForSEO returns 20100 ("login or password incorrect") inside
+    // a 200 response body; AppError::Api wraps it.
+    lc.includes("20100") ||
+    lc.includes("status_code: 20100")
+  );
 }

--- a/apps/dataforseo-app/src/routes/SettingsPage.tsx
+++ b/apps/dataforseo-app/src/routes/SettingsPage.tsx
@@ -236,6 +236,28 @@ export default function SettingsPage() {
           })}
         </div>
       </div>
+
+      <div>
+        <h3 className="text-sm font-semibold">Setup</h3>
+        <p className="mt-1 text-xs text-slate-500">
+          Re-run the first-run wizard to change credentials, budget, or pick a different
+          starter project. Existing data is left untouched.
+        </p>
+        <button
+          type="button"
+          onClick={async () => {
+            try {
+              await tauriApi.clearCredentials();
+              window.location.reload();
+            } catch (e) {
+              toast.error(`Failed: ${(e as { message?: string })?.message ?? e}`);
+            }
+          }}
+          className="mt-2 rounded border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+        >
+          Re-run onboarding
+        </button>
+      </div>
     </section>
   );
 }

--- a/apps/dataforseo-app/src/routes/domain/CompetitorsDomainTab.tsx
+++ b/apps/dataforseo-app/src/routes/domain/CompetitorsDomainTab.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import { DEFAULT_LANGUAGE, DEFAULT_LOCATION } from "../../lib/constants";
 import { formatUsd } from "../../lib/format";
-import { tauriApi, type CompetitorsDomainView } from "../../lib/tauri";
+import { tauriApi, type CompetitorDomain, type CompetitorsDomainView } from "../../lib/tauri";
 
 interface Props {
   target: string;
@@ -15,6 +17,16 @@ export default function CompetitorsDomainTab({ target }: Props) {
   const [view, setView] = useState<CompetitorsDomainView | null>(null);
 
   const trimmed = target.trim();
+
+  const exportColumns = useMemo<ColumnDef<CompetitorDomain, unknown>[]>(
+    () => [
+      { id: "domain", header: "Competitor", accessorKey: "domain" },
+      { id: "intersections", header: "Shared Keywords", accessorKey: "intersections" },
+      { id: "avg_position", header: "Avg Position", accessorKey: "avg_position" },
+      { id: "sum_position", header: "Sum Position", accessorKey: "sum_position" },
+    ],
+    [],
+  );
 
   async function onRun() {
     if (!trimmed) return;
@@ -67,9 +79,16 @@ export default function CompetitorsDomainTab({ target }: Props) {
 
       {view && view.items.length > 0 ? (
         <div className="flex flex-col gap-2">
-          <p className="text-xs text-slate-500">
-            {view.items.length} competitors for {view.target} · {formatUsd(view.cost_usd)}
-          </p>
+          <div className="flex items-center justify-between text-xs text-slate-500">
+            <span>
+              {view.items.length} competitors for {view.target} · {formatUsd(view.cost_usd)}
+            </span>
+            <ExportMenu
+              filenameStem={`competitors-${view.target}`}
+              rows={view.items}
+              columns={exportColumns}
+            />
+          </div>
           <div className="overflow-x-auto rounded border bg-white">
             <table className="min-w-full text-xs">
               <thead className="bg-slate-50 text-slate-600">

--- a/apps/dataforseo-app/src/routes/domain/DomainIntersectionTab.tsx
+++ b/apps/dataforseo-app/src/routes/domain/DomainIntersectionTab.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import { DEFAULT_LANGUAGE, DEFAULT_LOCATION } from "../../lib/constants";
 import { formatUsd } from "../../lib/format";
-import { tauriApi, type DomainIntersectionView } from "../../lib/tauri";
+import { tauriApi, type DomainIntersectionView, type IntersectionKeyword } from "../../lib/tauri";
 
 export default function DomainIntersectionTab() {
   const [target1, setTarget1] = useState("");
@@ -15,6 +17,19 @@ export default function DomainIntersectionTab() {
   const t1 = target1.trim();
   const t2 = target2.trim();
   const canRun = t1.length > 0 && t2.length > 0;
+
+  const exportColumns = useMemo<ColumnDef<IntersectionKeyword, unknown>[]>(
+    () => [
+      { id: "keyword", header: "Keyword", accessorKey: "keyword" },
+      { id: "search_volume", header: "Volume", accessorKey: "search_volume" },
+      { id: "keyword_difficulty", header: "KD", accessorKey: "keyword_difficulty" },
+      { id: "rank_first", header: "Domain 1 Pos", accessorKey: "rank_first" },
+      { id: "rank_second", header: "Domain 2 Pos", accessorKey: "rank_second" },
+      { id: "url_first", header: "Domain 1 URL", accessorKey: "url_first" },
+      { id: "url_second", header: "Domain 2 URL", accessorKey: "url_second" },
+    ],
+    [],
+  );
 
   async function onRun() {
     if (!canRun) return;
@@ -91,10 +106,17 @@ export default function DomainIntersectionTab() {
 
       {view && view.items.length > 0 ? (
         <div className="flex flex-col gap-2">
-          <p className="text-xs text-slate-500">
-            {view.items.length} shared keywords for {view.target1} vs {view.target2} ·{" "}
-            {formatUsd(view.cost_usd)}
-          </p>
+          <div className="flex items-center justify-between text-xs text-slate-500">
+            <span>
+              {view.items.length} shared keywords for {view.target1} vs {view.target2} ·{" "}
+              {formatUsd(view.cost_usd)}
+            </span>
+            <ExportMenu
+              filenameStem={`intersection-${view.target1}-vs-${view.target2}`}
+              rows={view.items}
+              columns={exportColumns}
+            />
+          </div>
           <div className="overflow-x-auto rounded border bg-white">
             <table className="min-w-full text-xs">
               <thead className="bg-slate-50 text-slate-600">

--- a/apps/dataforseo-app/src/routes/domain/KeywordGapTab.tsx
+++ b/apps/dataforseo-app/src/routes/domain/KeywordGapTab.tsx
@@ -148,8 +148,11 @@ export default function KeywordGapTab() {
             </span>
             <span className="ml-auto">
               <ExportMenu
-                filenameStem={`keyword-gap-${view.yours}-vs-${view.competitor}`}
-                rows={view.items}
+                // Match the visible bucket — exporting the full union
+                // would surprise the user since the on-screen table is
+                // already scoped to one of missing/weak/strong/unique.
+                filenameStem={`keyword-gap-${view.yours}-vs-${view.competitor}-${activeBucket}`}
+                rows={filtered}
                 columns={exportColumns}
               />
             </span>

--- a/apps/dataforseo-app/src/routes/domain/KeywordGapTab.tsx
+++ b/apps/dataforseo-app/src/routes/domain/KeywordGapTab.tsx
@@ -1,7 +1,9 @@
+import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import { DEFAULT_LANGUAGE, DEFAULT_LOCATION } from "../../lib/constants";
 import { formatUsd } from "../../lib/format";
 import { tauriApi, type GapKeyword, type KeywordGapView } from "../../lib/tauri";
@@ -59,6 +61,19 @@ export default function KeywordGapTab() {
   const filtered = useMemo<GapKeyword[]>(
     () => (view ? view.items.filter((k) => k.bucket === activeBucket) : []),
     [view, activeBucket],
+  );
+
+  const exportColumns = useMemo<ColumnDef<GapKeyword, unknown>[]>(
+    () => [
+      { id: "keyword", header: "Keyword", accessorKey: "keyword" },
+      { id: "bucket", header: "Bucket", accessorKey: "bucket" },
+      { id: "search_volume", header: "Volume", accessorKey: "search_volume" },
+      { id: "keyword_difficulty", header: "KD", accessorKey: "keyword_difficulty" },
+      { id: "cpc", header: "CPC", accessorKey: "cpc" },
+      { id: "rank_yours", header: "Your Rank", accessorKey: "rank_yours" },
+      { id: "rank_theirs", header: "Their Rank", accessorKey: "rank_theirs" },
+    ],
+    [],
   );
 
   return (
@@ -130,6 +145,13 @@ export default function KeywordGapTab() {
             <span>
               {view.yours} vs {view.competitor} · actual {formatUsd(view.cost_usd)} · estimated{" "}
               {formatUsd(view.estimated_usd)}
+            </span>
+            <span className="ml-auto">
+              <ExportMenu
+                filenameStem={`keyword-gap-${view.yours}-vs-${view.competitor}`}
+                rows={view.items}
+                columns={exportColumns}
+              />
             </span>
           </div>
 

--- a/apps/dataforseo-app/src/routes/keywords/BulkVolumeTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/BulkVolumeTab.tsx
@@ -1,11 +1,13 @@
+import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import CacheBadge from "../../components/CacheBadge";
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import { DEFAULT_LANGUAGE, DEFAULT_LOCATION } from "../../lib/constants";
 import { formatUsd } from "../../lib/format";
-import { tauriApi, type BulkVolumeView } from "../../lib/tauri";
+import { tauriApi, type BulkVolumeItem, type BulkVolumeView } from "../../lib/tauri";
 
 const MAX_KEYWORDS = 1000;
 
@@ -61,6 +63,17 @@ export default function BulkVolumeTab() {
           )
         : [],
     [view],
+  );
+
+  const exportColumns = useMemo<ColumnDef<BulkVolumeItem, unknown>[]>(
+    () => [
+      { id: "keyword", header: "Keyword", accessorKey: "keyword" },
+      { id: "search_volume", header: "Volume", accessorKey: "search_volume" },
+      { id: "competition", header: "Competition", accessorKey: "competition" },
+      { id: "competition_level", header: "Level", accessorKey: "competition_level" },
+      { id: "cpc", header: "CPC", accessorKey: "cpc" },
+    ],
+    [],
   );
 
   return (
@@ -123,6 +136,9 @@ export default function BulkVolumeTab() {
           <span>
             {view.items.length} rows · actual {formatUsd(view.cost_usd)} · estimated{" "}
             {formatUsd(view.estimated_usd)}
+          </span>
+          <span className="ml-auto">
+            <ExportMenu filenameStem="bulk-volume" rows={sorted} columns={exportColumns} />
           </span>
         </div>
       )}

--- a/apps/dataforseo-app/src/routes/keywords/DifficultyTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/DifficultyTab.tsx
@@ -131,6 +131,13 @@ function DifficultyTable({ view }: { view: BulkDifficultyView }) {
     () => [
       { id: "keyword", header: "Keyword", accessorKey: "keyword" },
       { id: "keyword_difficulty", header: "Difficulty", accessorKey: "keyword_difficulty" },
+      // Mirror the on-screen "Bucket" column so the CSV/JSON matches
+      // what the user is looking at.
+      {
+        id: "bucket",
+        header: "Bucket",
+        accessorFn: (row) => bucketLabel(row.keyword_difficulty),
+      },
     ],
     [],
   );

--- a/apps/dataforseo-app/src/routes/keywords/DifficultyTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/DifficultyTab.tsx
@@ -1,11 +1,14 @@
+import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import { DEFAULT_LANGUAGE, DEFAULT_LOCATION } from "../../lib/constants";
 import { formatUsd } from "../../lib/format";
 import {
   tauriApi,
+  type BulkDifficultyItem,
   type BulkDifficultyView,
 } from "../../lib/tauri";
 
@@ -124,6 +127,14 @@ function DifficultyTable({ view }: { view: BulkDifficultyView }) {
     [view.items],
   );
 
+  const exportColumns = useMemo<ColumnDef<BulkDifficultyItem, unknown>[]>(
+    () => [
+      { id: "keyword", header: "Keyword", accessorKey: "keyword" },
+      { id: "keyword_difficulty", header: "Difficulty", accessorKey: "keyword_difficulty" },
+    ],
+    [],
+  );
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
@@ -132,6 +143,11 @@ function DifficultyTable({ view }: { view: BulkDifficultyView }) {
           actual {formatUsd(view.cost_usd)} · estimated{" "}
           {formatUsd(view.estimated_usd)}
         </span>
+        <ExportMenu
+          filenameStem="keyword-difficulty"
+          rows={sorted}
+          columns={exportColumns}
+        />
       </div>
       <div className="overflow-x-auto rounded border bg-white">
         <table className="min-w-full text-xs">

--- a/apps/dataforseo-app/src/routes/keywords/SerpCompetitorsTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/SerpCompetitorsTab.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import { DEFAULT_LANGUAGE, DEFAULT_LOCATION } from "../../lib/constants";
 import { formatUsd } from "../../lib/format";
-import { tauriApi, type SerpCompetitorsView } from "../../lib/tauri";
+import { tauriApi, type SerpCompetitor, type SerpCompetitorsView } from "../../lib/tauri";
 
 export default function SerpCompetitorsTab() {
   const [keyword, setKeyword] = useState("");
@@ -12,6 +14,18 @@ export default function SerpCompetitorsTab() {
   const [view, setView] = useState<SerpCompetitorsView | null>(null);
 
   const trimmed = keyword.trim();
+
+  const exportColumns = useMemo<ColumnDef<SerpCompetitor, unknown>[]>(
+    () => [
+      { id: "domain", header: "Domain", accessorKey: "domain" },
+      { id: "avg_position", header: "Avg Position", accessorKey: "avg_position" },
+      { id: "median_position", header: "Median Position", accessorKey: "median_position" },
+      { id: "etv", header: "ETV", accessorKey: "etv" },
+      { id: "count", header: "Keywords", accessorKey: "count" },
+      { id: "rating", header: "Rating", accessorKey: "rating" },
+    ],
+    [],
+  );
 
   async function onRun() {
     if (!trimmed) return;
@@ -73,9 +87,17 @@ export default function SerpCompetitorsTab() {
 
       {view && view.items.length > 0 ? (
         <div className="flex flex-col gap-2">
-          <p className="text-xs text-slate-500">
-            {view.items.length} domains ranking for &ldquo;{view.keyword}&rdquo; · {formatUsd(view.cost_usd)}
-          </p>
+          <div className="flex items-center justify-between text-xs text-slate-500">
+            <span>
+              {view.items.length} domains ranking for &ldquo;{view.keyword}&rdquo; ·{" "}
+              {formatUsd(view.cost_usd)}
+            </span>
+            <ExportMenu
+              filenameStem={`serp-competitors-${view.keyword}`}
+              rows={view.items}
+              columns={exportColumns}
+            />
+          </div>
           <div className="overflow-x-auto rounded border bg-white">
             <table className="min-w-full text-xs">
               <thead className="bg-slate-50 text-slate-600">


### PR DESCRIPTION
## Summary

Phase C UX polish — completes the second batch of post-PR-#45 deferred items.

### C4 — ExportMenu rollout (6 tabs)

Adds CSV/JSON export to every tabular result view that previously lacked it. Each tab now renders an `<ExportMenu>` in its result-summary row using the shared component already in use on the SERP/Backlinks tabs.

- **keywords/DifficultyTab** — keyword + difficulty
- **keywords/BulkVolumeTab** — keyword + volume + competition + level + cpc
- **keywords/SerpCompetitorsTab** — domain + avg/median position + ETV + keywords + rating
- **domain/CompetitorsDomainTab** — competitor + intersections + avg/sum position
- **domain/DomainIntersectionTab** — keyword + volume + KD + per-domain rank/URL
- **domain/KeywordGapTab** — keyword + bucket + volume + KD + CPC + per-side rank

Single-record tabs (KeywordOverview / RankOverview / Lighthouse / InstantPage / AiOverview) deliberately skipped — their CSV/JSON shape doesn't fit a single dashboard view; "copy to clipboard" is the right primitive there.

### C6 — First-run onboarding wizard

A 4-step wizard that runs whenever `tauriApi.testConnection` errors (so first launch and after credential clears). Replaces the silent runtime crash users would hit when opening any data tab without DataForSEO creds configured.

1. **Welcome** — overview + DataForSEO sign-up link + 50 USD deposit / 100 USD/mo Backlinks minimums called out.
2. **Credentials** — login + password. Submitting calls `saveCredentials` → `testConnection`; only advances on a verified connection.
3. **Budget** — daily USD limit + alert threshold. Defaults to 5 USD/day at 80% alert.
4. **First project** — target domain + optional friendly name. Calls `projectsCreate` so the user has at least one project on first launch.

Plus a **Re-run onboarding** button on `/settings` that calls `clearCredentials` and reloads — the next mount sees no creds and re-renders the wizard.

### Plumbing

- New `useOnboardingGate()` hook in `OnboardingPage.tsx`; `App.tsx` renders the wizard, a `Connecting…` splash, or the main UI based on the three-state result.
- TypeScript `npx tsc --noEmit` clean.
- 6 vitest tests still pass.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` 6/6 pass
- [ ] Wipe credentials → re-launch → onboarding wizard renders
- [ ] Complete all 4 steps → `Open the app` flips into the normal UI without reload
- [ ] Settings → Re-run onboarding → reloads with wizard
- [ ] Each ExportMenu downloads a CSV/JSON whose columns match the on-screen table

---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_