### PR TITLE
feat(dataforseo-app): C3 — scheduled PDF reports

### DIFF
--- a/apps/dataforseo-app/src-tauri/Cargo.toml
+++ b/apps/dataforseo-app/src-tauri/Cargo.toml
@@ -34,6 +34,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "serd
 keyring = "3"
 
 ts-rs = { version = "10", features = ["serde-json-impl"] }
+printpdf = { version = "0.7", default-features = false }
 
 [dev-dependencies]
 proptest = "1"

--- a/apps/dataforseo-app/src-tauri/migrations/v0008_reports.sql
+++ b/apps/dataforseo-app/src-tauri/migrations/v0008_reports.sql
@@ -1,0 +1,27 @@
+-- Scheduled PDF reports. Users configure schedules (one per project +
+-- kind) and the background reporter task generates a PDF to the local
+-- Documents folder on each tick. Runs are recorded so the UI can list
+-- past files and offer "Open PDF" buttons.
+--
+-- Supported kinds:   'daily-tracking' | 'weekly-audit' | 'weekly-brand'
+-- Supported cadences:'daily' | 'weekly'
+
+CREATE TABLE IF NOT EXISTS report_schedules (
+    id         BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    project_id BIGINT,
+    kind       VARCHAR NOT NULL,
+    cadence    VARCHAR NOT NULL,
+    active     BOOLEAN DEFAULT TRUE,
+    last_run_at TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS report_runs (
+    id          BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
+    schedule_id BIGINT  NOT NULL,
+    pdf_path    VARCHAR NOT NULL,
+    generated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS report_schedules_project_idx ON report_schedules(project_id);
+CREATE INDEX IF NOT EXISTS report_runs_schedule_idx     ON report_runs(schedule_id);

--- a/apps/dataforseo-app/src-tauri/migrations/v0008_reports.sql
+++ b/apps/dataforseo-app/src-tauri/migrations/v0008_reports.sql
@@ -3,12 +3,14 @@
 -- Documents folder on each tick. Runs are recorded so the UI can list
 -- past files and offer "Open PDF" buttons.
 --
--- Supported kinds:   'daily-tracking' | 'weekly-audit' | 'weekly-brand'
--- Supported cadences:'daily' | 'weekly'
+-- Supported kinds:    'daily-tracking' | 'weekly-audit' | 'weekly-brand'
+-- Supported cadences: 'daily' | 'weekly'
 
 CREATE TABLE IF NOT EXISTS report_schedules (
     id         BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    project_id BIGINT,
+    -- NULL means "all projects / global". SET NULL on project delete keeps
+    -- the schedule around as an unscoped report.
+    project_id BIGINT REFERENCES projects(id) ON DELETE SET NULL,
     kind       VARCHAR NOT NULL,
     cadence    VARCHAR NOT NULL,
     active     BOOLEAN DEFAULT TRUE,
@@ -18,7 +20,8 @@ CREATE TABLE IF NOT EXISTS report_schedules (
 
 CREATE TABLE IF NOT EXISTS report_runs (
     id          BIGINT PRIMARY KEY GENERATED ALWAYS AS IDENTITY,
-    schedule_id BIGINT  NOT NULL,
+    -- Cascade: deleting a schedule removes all its historical runs.
+    schedule_id BIGINT  NOT NULL REFERENCES report_schedules(id) ON DELETE CASCADE,
     pdf_path    VARCHAR NOT NULL,
     generated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/apps/dataforseo-app/src-tauri/src/commands/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod keywords;
 pub mod ledger;
 pub mod on_page;
 pub mod projects;
+pub mod reports;
 pub mod serp;
 pub mod topic;
 pub mod tracking;

--- a/apps/dataforseo-app/src-tauri/src/commands/reports.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/reports.rs
@@ -1,0 +1,73 @@
+//! Commands for managing scheduled PDF reports.
+
+use tauri::State;
+use tokio::task;
+
+use crate::errors::{AppError, Result};
+use crate::state::AppState;
+use crate::store::reports::{self, ReportRun, ReportSchedule};
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn reports_list_schedules(state: State<'_, AppState>) -> Result<Vec<ReportSchedule>> {
+    let store = state.store.clone();
+    task::spawn_blocking(move || store.with_conn(reports::list_schedules))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn reports_create_schedule(
+    state: State<'_, AppState>,
+    project_id: Option<i64>,
+    kind: String,
+    cadence: String,
+) -> Result<i64> {
+    let valid_kinds = ["daily-tracking", "weekly-audit", "weekly-brand"];
+    let valid_cadences = ["daily", "weekly"];
+    if !valid_kinds.contains(&kind.as_str()) {
+        return Err(AppError::Validation(format!("invalid kind: {kind}")));
+    }
+    if !valid_cadences.contains(&cadence.as_str()) {
+        return Err(AppError::Validation(format!("invalid cadence: {cadence}")));
+    }
+    let store = state.store.clone();
+    task::spawn_blocking(move || store.with_conn(|c| reports::create_schedule(c, project_id, &kind, &cadence)))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn reports_toggle_schedule(
+    state: State<'_, AppState>,
+    id: i64,
+    active: bool,
+) -> Result<()> {
+    let store = state.store.clone();
+    task::spawn_blocking(move || store.with_conn(|c| reports::toggle_schedule(c, id, active)))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn reports_delete_schedule(state: State<'_, AppState>, id: i64) -> Result<()> {
+    let store = state.store.clone();
+    task::spawn_blocking(move || store.with_conn(|c| reports::delete_schedule(c, id)))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn reports_list_runs(
+    state: State<'_, AppState>,
+    schedule_id: i64,
+) -> Result<Vec<ReportRun>> {
+    let store = state.store.clone();
+    task::spawn_blocking(move || store.with_conn(|c| reports::list_runs(c, schedule_id, 20)))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?
+}

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -55,6 +55,8 @@ pub fn run() {
             let tracker_store = store.clone();
             let audit_api = api.clone();
             let audit_store = store.clone();
+            let reporter_store = store.clone();
+            let docs_dir = app.path().document_dir().ok();
             app.manage(state);
             tauri::async_runtime::spawn(async move {
                 tasks::poller::run(api, store).await;
@@ -64,6 +66,9 @@ pub fn run() {
             });
             tauri::async_runtime::spawn(async move {
                 tasks::audit_poller::run(audit_api, audit_store).await;
+            });
+            tauri::async_runtime::spawn(async move {
+                tasks::reporter::run(reporter_store, docs_dir).await;
             });
             Ok(())
         })
@@ -185,6 +190,11 @@ pub fn run() {
             commands::ai::chat_list_sessions,
             commands::ai::chat_history,
             commands::ai::chat_send,
+            commands::reports::reports_list_schedules,
+            commands::reports::reports_create_schedule,
+            commands::reports::reports_toggle_schedule,
+            commands::reports::reports_delete_schedule,
+            commands::reports::reports_list_runs,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/dataforseo-app/src-tauri/src/store/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/mod.rs
@@ -1,4 +1,5 @@
 pub mod audits;
+pub mod reports;
 pub mod backlinks;
 pub mod chat;
 pub mod cost_budget;

--- a/apps/dataforseo-app/src-tauri/src/store/reports.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/reports.rs
@@ -55,14 +55,10 @@ pub fn create_schedule(
     kind: &str,
     cadence: &str,
 ) -> Result<i64> {
-    conn.execute(
-        "INSERT INTO report_schedules (project_id, kind, cadence)
-         VALUES ($1, $2, $3)",
-        params![project_id, kind, cadence],
-    )?;
     let id: i64 = conn.query_row(
-        "SELECT MAX(id) FROM report_schedules",
-        [],
+        "INSERT INTO report_schedules (project_id, kind, cadence)
+         VALUES ($1, $2, $3) RETURNING id",
+        params![project_id, kind, cadence],
         |row| row.get(0),
     )?;
     Ok(id)
@@ -76,9 +72,13 @@ pub fn toggle_schedule(conn: &mut Connection, id: i64, active: bool) -> Result<(
     Ok(())
 }
 
+/// Cascade-deletes child runs before removing the schedule row. The FK
+/// `ON DELETE CASCADE` on report_runs.schedule_id handles this automatically,
+/// but the explicit delete is kept as a safety net for environments without
+/// FK enforcement.
 pub fn delete_schedule(conn: &mut Connection, id: i64) -> Result<()> {
-    conn.execute("DELETE FROM report_runs    WHERE schedule_id = $1", params![id])?;
-    conn.execute("DELETE FROM report_schedules WHERE id = $1", params![id])?;
+    conn.execute("DELETE FROM report_runs      WHERE schedule_id = $1", params![id])?;
+    conn.execute("DELETE FROM report_schedules WHERE id = $1",          params![id])?;
     Ok(())
 }
 
@@ -102,13 +102,9 @@ pub fn list_runs(conn: &mut Connection, schedule_id: i64, limit: u32) -> Result<
 }
 
 pub fn record_run(conn: &mut Connection, schedule_id: i64, pdf_path: &str) -> Result<i64> {
-    conn.execute(
-        "INSERT INTO report_runs (schedule_id, pdf_path) VALUES ($1, $2)",
-        params![schedule_id, pdf_path],
-    )?;
     let id: i64 = conn.query_row(
-        "SELECT MAX(id) FROM report_runs WHERE schedule_id = $1",
-        params![schedule_id],
+        "INSERT INTO report_runs (schedule_id, pdf_path) VALUES ($1, $2) RETURNING id",
+        params![schedule_id, pdf_path],
         |row| row.get(0),
     )?;
     Ok(id)
@@ -122,7 +118,7 @@ pub fn mark_ran(conn: &mut Connection, id: i64) -> Result<()> {
     Ok(())
 }
 
-/// Pull schedules that are due: active + overdue for their cadence.
+/// Pull schedules that are active and overdue for their cadence.
 pub fn due_schedules(conn: &mut Connection) -> Result<Vec<ReportSchedule>> {
     let mut stmt = conn.prepare(
         "SELECT id, project_id, kind, cadence, active,

--- a/apps/dataforseo-app/src-tauri/src/store/reports.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/reports.rs
@@ -1,0 +1,152 @@
+//! CRUD for scheduled PDF reports.
+
+use duckdb::{params, Connection};
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+use crate::errors::Result;
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct ReportSchedule {
+    pub id: i64,
+    pub project_id: Option<i64>,
+    pub kind: String,
+    pub cadence: String,
+    pub active: bool,
+    pub last_run_at: Option<String>,
+    pub created_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct ReportRun {
+    pub id: i64,
+    pub schedule_id: i64,
+    pub pdf_path: String,
+    pub generated_at: Option<String>,
+}
+
+pub fn list_schedules(conn: &mut Connection) -> Result<Vec<ReportSchedule>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, project_id, kind, cadence, active,
+                CAST(last_run_at AS VARCHAR), CAST(created_at AS VARCHAR)
+         FROM report_schedules ORDER BY created_at ASC, id ASC",
+    )?;
+    let mut rows = stmt.query([])?;
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        out.push(ReportSchedule {
+            id: row.get(0)?,
+            project_id: row.get(1)?,
+            kind: row.get(2)?,
+            cadence: row.get(3)?,
+            active: row.get(4)?,
+            last_run_at: row.get(5)?,
+            created_at: row.get(6)?,
+        });
+    }
+    Ok(out)
+}
+
+pub fn create_schedule(
+    conn: &mut Connection,
+    project_id: Option<i64>,
+    kind: &str,
+    cadence: &str,
+) -> Result<i64> {
+    conn.execute(
+        "INSERT INTO report_schedules (project_id, kind, cadence)
+         VALUES ($1, $2, $3)",
+        params![project_id, kind, cadence],
+    )?;
+    let id: i64 = conn.query_row(
+        "SELECT MAX(id) FROM report_schedules",
+        [],
+        |row| row.get(0),
+    )?;
+    Ok(id)
+}
+
+pub fn toggle_schedule(conn: &mut Connection, id: i64, active: bool) -> Result<()> {
+    conn.execute(
+        "UPDATE report_schedules SET active = $1 WHERE id = $2",
+        params![active, id],
+    )?;
+    Ok(())
+}
+
+pub fn delete_schedule(conn: &mut Connection, id: i64) -> Result<()> {
+    conn.execute("DELETE FROM report_runs    WHERE schedule_id = $1", params![id])?;
+    conn.execute("DELETE FROM report_schedules WHERE id = $1", params![id])?;
+    Ok(())
+}
+
+pub fn list_runs(conn: &mut Connection, schedule_id: i64, limit: u32) -> Result<Vec<ReportRun>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, schedule_id, pdf_path, CAST(generated_at AS VARCHAR)
+         FROM report_runs WHERE schedule_id = $1
+         ORDER BY generated_at DESC LIMIT $2",
+    )?;
+    let mut rows = stmt.query(params![schedule_id, limit])?;
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        out.push(ReportRun {
+            id: row.get(0)?,
+            schedule_id: row.get(1)?,
+            pdf_path: row.get(2)?,
+            generated_at: row.get(3)?,
+        });
+    }
+    Ok(out)
+}
+
+pub fn record_run(conn: &mut Connection, schedule_id: i64, pdf_path: &str) -> Result<i64> {
+    conn.execute(
+        "INSERT INTO report_runs (schedule_id, pdf_path) VALUES ($1, $2)",
+        params![schedule_id, pdf_path],
+    )?;
+    let id: i64 = conn.query_row(
+        "SELECT MAX(id) FROM report_runs WHERE schedule_id = $1",
+        params![schedule_id],
+        |row| row.get(0),
+    )?;
+    Ok(id)
+}
+
+pub fn mark_ran(conn: &mut Connection, id: i64) -> Result<()> {
+    conn.execute(
+        "UPDATE report_schedules SET last_run_at = CURRENT_TIMESTAMP WHERE id = $1",
+        params![id],
+    )?;
+    Ok(())
+}
+
+/// Pull schedules that are due: active + overdue for their cadence.
+pub fn due_schedules(conn: &mut Connection) -> Result<Vec<ReportSchedule>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, project_id, kind, cadence, active,
+                CAST(last_run_at AS VARCHAR), CAST(created_at AS VARCHAR)
+         FROM report_schedules
+         WHERE active = TRUE
+           AND (
+             (cadence = 'daily'  AND (last_run_at IS NULL OR last_run_at < NOW() - INTERVAL '1 day'))
+          OR (cadence = 'weekly' AND (last_run_at IS NULL OR last_run_at < NOW() - INTERVAL '7 days'))
+           )
+         ORDER BY id ASC",
+    )?;
+    let mut rows = stmt.query([])?;
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        out.push(ReportSchedule {
+            id: row.get(0)?,
+            project_id: row.get(1)?,
+            kind: row.get(2)?,
+            cadence: row.get(3)?,
+            active: row.get(4)?,
+            last_run_at: row.get(5)?,
+            created_at: row.get(6)?,
+        });
+    }
+    Ok(out)
+}

--- a/apps/dataforseo-app/src-tauri/src/store/schema.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/schema.rs
@@ -12,6 +12,7 @@ const MIGRATIONS: &[(u32, &str)] = &[
     (5, include_str!("../../migrations/v0005_position_tracking.sql")),
     (6, include_str!("../../migrations/v0006_site_audit.sql")),
     (7, include_str!("../../migrations/v0007_projects.sql")),
+    (8, include_str!("../../migrations/v0008_reports.sql")),
 ];
 
 pub fn ensure_current(conn: &mut Connection) -> Result<()> {

--- a/apps/dataforseo-app/src-tauri/src/tasks/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/tasks/mod.rs
@@ -1,3 +1,4 @@
 pub mod audit_poller;
 pub mod poller;
+pub mod reporter;
 pub mod tracker;

--- a/apps/dataforseo-app/src-tauri/src/tasks/reporter.rs
+++ b/apps/dataforseo-app/src-tauri/src/tasks/reporter.rs
@@ -1,0 +1,224 @@
+//! Scheduled PDF report generator. Wakes every hour and checks for
+//! due report_schedules. For each due schedule it:
+//!   1. Fetches relevant data from the local DB.
+//!   2. Renders a single-page (or multi-page) A4 PDF via printpdf.
+//!   3. Writes the file to <docs_dir>/DataForSEO Reports/.
+//!   4. Records the run in report_runs + bumps last_run_at.
+//!
+//! Failures are per-schedule and logged; they don't kill the loop.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use printpdf::{BuiltinFont, Mm, PdfDocument};
+use tokio::time;
+
+use crate::errors::{AppError, Result};
+use crate::store::reports::{self, ReportSchedule};
+use crate::store::tracking;
+use crate::store::Store;
+
+const TICK_INTERVAL_SECS: u64 = 60 * 60; // 1h
+
+pub async fn run(store: Arc<Store>, docs_dir: Option<PathBuf>) {
+    tracing::info!("reporter started (interval {}s)", TICK_INTERVAL_SECS);
+    loop {
+        time::sleep(Duration::from_secs(TICK_INTERVAL_SECS)).await;
+        if let Err(e) = tick(&store, docs_dir.as_deref()).await {
+            tracing::warn!(error = %e, "reporter tick failed");
+        }
+    }
+}
+
+async fn tick(store: &Arc<Store>, docs_dir: Option<&Path>) -> Result<()> {
+    let store_c = store.clone();
+    let due = tokio::task::spawn_blocking(move || store_c.with_conn(reports::due_schedules))
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))??;
+
+    if due.is_empty() {
+        return Ok(());
+    }
+    tracing::info!(count = due.len(), "reporter: generating due reports");
+
+    for sched in due {
+        if let Err(e) = generate_one(store, docs_dir, &sched).await {
+            tracing::warn!(id = sched.id, kind = %sched.kind, error = %e, "report generation failed");
+        }
+    }
+    Ok(())
+}
+
+async fn generate_one(
+    store: &Arc<Store>,
+    docs_dir: Option<&Path>,
+    sched: &ReportSchedule,
+) -> Result<()> {
+    let out_dir = docs_dir
+        .map(|d| d.join("DataForSEO Reports"))
+        .unwrap_or_else(|| PathBuf::from("DataForSEO Reports"));
+    std::fs::create_dir_all(&out_dir)
+        .map_err(|e| AppError::Internal(format!("create reports dir: {e}")))?;
+
+    let pdf_bytes = match sched.kind.as_str() {
+        "daily-tracking" => build_tracking_pdf(store, sched).await?,
+        "weekly-audit" => build_audit_pdf(sched),
+        "weekly-brand" => build_brand_pdf(sched),
+        other => {
+            tracing::warn!(kind = %other, "unknown report kind — skipping");
+            return Ok(());
+        }
+    };
+
+    let ts = chrono::Local::now().format("%Y%m%d-%H%M%S");
+    let filename = format!("{}-{}-{}.pdf", sched.kind, sched.id, ts);
+    let pdf_path = out_dir.join(&filename);
+    std::fs::write(&pdf_path, &pdf_bytes)
+        .map_err(|e| AppError::Internal(format!("write PDF: {e}")))?;
+
+    let path_str = pdf_path.to_string_lossy().into_owned();
+    let sched_id = sched.id;
+    let store_c = store.clone();
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        store_c.with_conn(|c| {
+            reports::record_run(c, sched_id, &path_str)?;
+            reports::mark_ran(c, sched_id)
+        })
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))??;
+
+    tracing::info!(path = %path_str, "report saved");
+    Ok(())
+}
+
+// ── PDF builders ───────────────────────────────────────────────────────────
+
+/// Tracking report: table of keyword → latest rank.
+async fn build_tracking_pdf(store: &Arc<Store>, sched: &ReportSchedule) -> Result<Vec<u8>> {
+    let store_c = store.clone();
+    let rows = tokio::task::spawn_blocking(move || -> Result<_> {
+        store_c.with_conn(|c| tracking::list_with_ranks(c))
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))??;
+
+    let title = format!("Keyword Tracking Report (schedule {})", sched.id);
+    let mut lines: Vec<(String, String, String)> = vec![
+        ("Keyword".into(), "Rank".into(), "Target".into()),
+    ];
+    for r in &rows {
+        let rank = r
+            .current_rank
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "—".into());
+        lines.push((r.keyword.keyword.clone(), rank, r.keyword.target.clone()));
+    }
+
+    build_table_pdf(&title, "Daily Tracking Report", &lines)
+}
+
+/// Audit report: placeholder (live data lives in response_cache by audit_run_id).
+fn build_audit_pdf(sched: &ReportSchedule) -> Vec<u8> {
+    let title = "Site Audit Weekly Report";
+    let lines = vec![
+        ("Section".into(), "Value".into(), "".into()),
+        ("Schedule".into(), sched.kind.clone(), "".into()),
+        ("Cadence".into(), sched.cadence.clone(), "".into()),
+        (
+            "Note".into(),
+            "Open the Audit tab for detailed results.".into(),
+            "".into(),
+        ),
+    ];
+    build_table_pdf(title, "Weekly Site Audit Summary", &lines).unwrap_or_default()
+}
+
+/// Brand report: placeholder summary.
+fn build_brand_pdf(sched: &ReportSchedule) -> Vec<u8> {
+    let title = "Brand Monitor Weekly Report";
+    let lines = vec![
+        ("Section".into(), "Value".into(), "".into()),
+        ("Schedule".into(), sched.kind.clone(), "".into()),
+        ("Cadence".into(), sched.cadence.clone(), "".into()),
+        (
+            "Note".into(),
+            "Open the Brand Monitor tab for detailed results.".into(),
+            "".into(),
+        ),
+    ];
+    build_table_pdf(title, "Weekly Brand Monitor Summary", &lines).unwrap_or_default()
+}
+
+// ── Generic PDF table builder ───────────────────────────────────────────────
+
+/// Build a simple A4 PDF with a heading and a 3-column table.
+/// Returns raw PDF bytes on success.
+fn build_table_pdf(
+    document_title: &str,
+    heading: &str,
+    rows: &[(String, String, String)],
+) -> Result<Vec<u8>> {
+    let (doc, page1, layer1) =
+        PdfDocument::new(document_title, Mm(210.0), Mm(297.0), "Layer 1");
+    let regular = doc
+        .add_builtin_font(BuiltinFont::Helvetica)
+        .map_err(|e| AppError::Internal(format!("font: {e}")))?;
+    let bold = doc
+        .add_builtin_font(BuiltinFont::HelveticaBold)
+        .map_err(|e| AppError::Internal(format!("font bold: {e}")))?;
+
+    let layer = doc.get_page(page1).get_layer(layer1);
+    let now = chrono::Local::now().format("%Y-%m-%d %H:%M").to_string();
+
+    // Header
+    layer.use_text(heading, 16.0, Mm(20.0), Mm(272.0), &bold);
+    layer.use_text(&now, 9.0, Mm(20.0), Mm(265.0), &regular);
+
+    // Separator line — ASCII only (built-in PDF fonts are Latin-1).
+    layer.use_text(
+        &"-".repeat(100),
+        8.0,
+        Mm(20.0),
+        Mm(261.0),
+        &regular,
+    );
+
+    // Table rows — col widths: 90 / 40 / 50 mm
+    const COL1: f32 = 20.0;
+    const COL2: f32 = 115.0;
+    const COL3: f32 = 160.0;
+    const ROW_H: f32 = 7.0;
+    let mut y = 255.0_f32;
+    let bottom_margin = 20.0_f32;
+
+    for (i, (c1, c2, c3)) in rows.iter().enumerate() {
+        if y < bottom_margin {
+            break; // don't overflow — add more pages in a future iteration
+        }
+        let font = if i == 0 { &bold } else { &regular };
+        layer.use_text(truncate(c1, 38), 9.0, Mm(COL1), Mm(y), font);
+        layer.use_text(truncate(c2, 20), 9.0, Mm(COL2), Mm(y), font);
+        layer.use_text(truncate(c3, 22), 9.0, Mm(COL3), Mm(y), font);
+        y -= ROW_H;
+    }
+
+    // Footer
+    layer.use_text("Generated by DataForSEO App", 8.0, Mm(20.0), Mm(10.0), &regular);
+
+    doc.save_to_bytes()
+        .map_err(|e| AppError::Internal(format!("PDF save: {e}")))
+}
+
+fn truncate(s: &str, max_chars: usize) -> &str {
+    if s.len() <= max_chars {
+        s
+    } else {
+        // Safe truncation at char boundary
+        match s.char_indices().nth(max_chars) {
+            Some((idx, _)) => &s[..idx],
+            None => s,
+        }
+    }
+}

--- a/apps/dataforseo-app/src-tauri/src/tasks/reporter.rs
+++ b/apps/dataforseo-app/src-tauri/src/tasks/reporter.rs
@@ -21,10 +21,14 @@ use crate::store::Store;
 
 const TICK_INTERVAL_SECS: u64 = 60 * 60; // 1h
 
+/// Uses `interval` (not `sleep`) so the first tick fires immediately on
+/// startup — any schedule that became due while the app was closed gets
+/// picked up right away rather than waiting a full hour.
 pub async fn run(store: Arc<Store>, docs_dir: Option<PathBuf>) {
     tracing::info!("reporter started (interval {}s)", TICK_INTERVAL_SECS);
+    let mut interval = time::interval(Duration::from_secs(TICK_INTERVAL_SECS));
     loop {
-        time::sleep(Duration::from_secs(TICK_INTERVAL_SECS)).await;
+        interval.tick().await;
         if let Err(e) = tick(&store, docs_dir.as_deref()).await {
             tracing::warn!(error = %e, "reporter tick failed");
         }
@@ -63,8 +67,8 @@ async fn generate_one(
 
     let pdf_bytes = match sched.kind.as_str() {
         "daily-tracking" => build_tracking_pdf(store, sched).await?,
-        "weekly-audit" => build_audit_pdf(sched),
-        "weekly-brand" => build_brand_pdf(sched),
+        "weekly-audit"   => build_audit_pdf(sched)?,
+        "weekly-brand"   => build_brand_pdf(sched)?,
         other => {
             tracing::warn!(kind = %other, "unknown report kind — skipping");
             return Ok(());
@@ -112,49 +116,39 @@ async fn build_tracking_pdf(store: &Arc<Store>, sched: &ReportSchedule) -> Resul
         let rank = r
             .current_rank
             .map(|v| v.to_string())
-            .unwrap_or_else(|| "—".into());
+            .unwrap_or_else(|| "-".into());
         lines.push((r.keyword.keyword.clone(), rank, r.keyword.target.clone()));
     }
 
     build_table_pdf(&title, "Daily Tracking Report", &lines)
 }
 
-/// Audit report: placeholder (live data lives in response_cache by audit_run_id).
-fn build_audit_pdf(sched: &ReportSchedule) -> Vec<u8> {
-    let title = "Site Audit Weekly Report";
+/// Audit report: summary placeholder (detailed data lives in the Audit tab).
+fn build_audit_pdf(sched: &ReportSchedule) -> Result<Vec<u8>> {
     let lines = vec![
         ("Section".into(), "Value".into(), "".into()),
         ("Schedule".into(), sched.kind.clone(), "".into()),
         ("Cadence".into(), sched.cadence.clone(), "".into()),
-        (
-            "Note".into(),
-            "Open the Audit tab for detailed results.".into(),
-            "".into(),
-        ),
+        ("Note".into(), "Open the Audit tab for detailed results.".into(), "".into()),
     ];
-    build_table_pdf(title, "Weekly Site Audit Summary", &lines).unwrap_or_default()
+    build_table_pdf("Site Audit Weekly Report", "Weekly Site Audit Summary", &lines)
 }
 
-/// Brand report: placeholder summary.
-fn build_brand_pdf(sched: &ReportSchedule) -> Vec<u8> {
-    let title = "Brand Monitor Weekly Report";
+/// Brand report: summary placeholder (detailed data lives in the Brand Monitor tab).
+fn build_brand_pdf(sched: &ReportSchedule) -> Result<Vec<u8>> {
     let lines = vec![
         ("Section".into(), "Value".into(), "".into()),
         ("Schedule".into(), sched.kind.clone(), "".into()),
         ("Cadence".into(), sched.cadence.clone(), "".into()),
-        (
-            "Note".into(),
-            "Open the Brand Monitor tab for detailed results.".into(),
-            "".into(),
-        ),
+        ("Note".into(), "Open the Brand Monitor tab for detailed results.".into(), "".into()),
     ];
-    build_table_pdf(title, "Weekly Brand Monitor Summary", &lines).unwrap_or_default()
+    build_table_pdf("Brand Monitor Weekly Report", "Weekly Brand Monitor Summary", &lines)
 }
 
 // ── Generic PDF table builder ───────────────────────────────────────────────
 
-/// Build a simple A4 PDF with a heading and a 3-column table.
-/// Returns raw PDF bytes on success.
+/// Build an A4 PDF with a heading and a 3-column table. Adds extra pages
+/// automatically when the table overflows the first page.
 fn build_table_pdf(
     document_title: &str,
     heading: &str,
@@ -169,43 +163,63 @@ fn build_table_pdf(
         .add_builtin_font(BuiltinFont::HelveticaBold)
         .map_err(|e| AppError::Internal(format!("font bold: {e}")))?;
 
-    let layer = doc.get_page(page1).get_layer(layer1);
     let now = chrono::Local::now().format("%Y-%m-%d %H:%M").to_string();
 
-    // Header
-    layer.use_text(heading, 16.0, Mm(20.0), Mm(272.0), &bold);
-    layer.use_text(&now, 9.0, Mm(20.0), Mm(265.0), &regular);
+    // Draw first-page header via a temporary layer reference.
+    {
+        let layer = doc.get_page(page1).get_layer(layer1);
+        layer.use_text(heading, 16.0, Mm(20.0), Mm(272.0), &bold);
+        layer.use_text(&now, 9.0, Mm(20.0), Mm(265.0), &regular);
+        layer.use_text(&"-".repeat(100), 8.0, Mm(20.0), Mm(261.0), &regular);
+    }
 
-    // Separator line — ASCII only (built-in PDF fonts are Latin-1).
-    layer.use_text(
-        &"-".repeat(100),
-        8.0,
-        Mm(20.0),
-        Mm(261.0),
-        &regular,
-    );
-
-    // Table rows — col widths: 90 / 40 / 50 mm
+    // Table layout constants.
     const COL1: f32 = 20.0;
     const COL2: f32 = 115.0;
     const COL3: f32 = 160.0;
     const ROW_H: f32 = 7.0;
-    let mut y = 255.0_f32;
-    let bottom_margin = 20.0_f32;
+    const BOTTOM_MARGIN: f32 = 20.0;
+    const TOP_Y: f32 = 255.0;        // first row y on page 1 (below header)
+    const CONT_TOP_Y: f32 = 277.0;   // first row y on continuation pages
+
+    let mut cur_page = page1;
+    let mut cur_layer = layer1;
+    let mut y = TOP_Y;
+    let mut page_num = 1u32;
 
     for (i, (c1, c2, c3)) in rows.iter().enumerate() {
-        if y < bottom_margin {
-            break; // don't overflow — add more pages in a future iteration
+        // Overflow → new page.
+        if y < BOTTOM_MARGIN {
+            page_num += 1;
+            let (np, nl) = doc.add_page(Mm(210.0), Mm(297.0), format!("Layer {page_num}"));
+            cur_page = np;
+            cur_layer = nl;
+            y = CONT_TOP_Y;
+            // Repeat the column header row on the continuation page.
+            if let Some((h1, h2, h3)) = rows.first() {
+                doc.get_page(cur_page).get_layer(cur_layer)
+                    .use_text(truncate(h1, 38), 9.0, Mm(COL1), Mm(y), &bold);
+                doc.get_page(cur_page).get_layer(cur_layer)
+                    .use_text(truncate(h2, 20), 9.0, Mm(COL2), Mm(y), &bold);
+                doc.get_page(cur_page).get_layer(cur_layer)
+                    .use_text(truncate(h3, 22), 9.0, Mm(COL3), Mm(y), &bold);
+                y -= ROW_H;
+            }
         }
+
         let font = if i == 0 { &bold } else { &regular };
-        layer.use_text(truncate(c1, 38), 9.0, Mm(COL1), Mm(y), font);
-        layer.use_text(truncate(c2, 20), 9.0, Mm(COL2), Mm(y), font);
-        layer.use_text(truncate(c3, 22), 9.0, Mm(COL3), Mm(y), font);
+        doc.get_page(cur_page).get_layer(cur_layer)
+            .use_text(truncate(c1, 38), 9.0, Mm(COL1), Mm(y), font);
+        doc.get_page(cur_page).get_layer(cur_layer)
+            .use_text(truncate(c2, 20), 9.0, Mm(COL2), Mm(y), font);
+        doc.get_page(cur_page).get_layer(cur_layer)
+            .use_text(truncate(c3, 22), 9.0, Mm(COL3), Mm(y), font);
         y -= ROW_H;
     }
 
-    // Footer
-    layer.use_text("Generated by DataForSEO App", 8.0, Mm(20.0), Mm(10.0), &regular);
+    // Footer on last page.
+    doc.get_page(cur_page).get_layer(cur_layer)
+        .use_text("Generated by DataForSEO App", 8.0, Mm(20.0), Mm(10.0), &regular);
 
     doc.save_to_bytes()
         .map_err(|e| AppError::Internal(format!("PDF save: {e}")))
@@ -215,7 +229,6 @@ fn truncate(s: &str, max_chars: usize) -> &str {
     if s.len() <= max_chars {
         s
     } else {
-        // Safe truncation at char boundary
         match s.char_indices().nth(max_chars) {
             Some((idx, _)) => &s[..idx],
             None => s,

--- a/apps/dataforseo-app/src/App.tsx
+++ b/apps/dataforseo-app/src/App.tsx
@@ -21,6 +21,7 @@ import TrackingPage from "./routes/TrackingPage";
 import SocialPage from "./routes/SocialPage";
 import TasksPage from "./routes/TasksPage";
 import TrafficPage from "./routes/TrafficPage";
+import ReportsPage from "./routes/ReportsPage";
 import UsagePage from "./routes/UsagePage";
 import SettingsPage from "./routes/SettingsPage";
 
@@ -42,6 +43,7 @@ const navItems = [
   { to: "/compare", label: "Compare" },
   { to: "/tasks", label: "Tasks" },
   { to: "/chat", label: "Chat" },
+  { to: "/reports", label: "Reports" },
   { to: "/usage", label: "Usage" },
   { to: "/settings", label: "Settings" },
 ];
@@ -131,6 +133,7 @@ function AppShell() {
           <Route path="/tasks" element={<TasksPage />} />
           <Route path="/chat" element={<ChatPage />} />
           <Route path="/chat/:sessionId" element={<ChatPage />} />
+          <Route path="/reports" element={<ReportsPage />} />
           <Route path="/usage" element={<UsagePage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Routes>

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -320,6 +320,16 @@ export const tauriApi = {
     invoke<void>("projects_rename", args),
   projectsDelete: (args: { id: number }) => invoke<void>("projects_delete", args),
 
+  reportsListSchedules: () => invoke<ReportSchedule[]>("reports_list_schedules"),
+  reportsCreateSchedule: (args: { projectId: number | null; kind: string; cadence: string }) =>
+    invoke<number>("reports_create_schedule", args),
+  reportsToggleSchedule: (args: { id: number; active: boolean }) =>
+    invoke<void>("reports_toggle_schedule", args),
+  reportsDeleteSchedule: (args: { id: number }) =>
+    invoke<void>("reports_delete_schedule", args),
+  reportsListRuns: (args: { scheduleId: number }) =>
+    invoke<ReportRun[]>("reports_list_runs", args),
+
   whoisOverview: (args: { domain: string; useCache: boolean }) =>
     invoke<WhoisView>("whois_overview", args),
 
@@ -795,6 +805,23 @@ export interface Project {
   name: string;
   target: string;
   created_at: string | null;
+}
+
+export interface ReportSchedule {
+  id: number;
+  project_id: number | null;
+  kind: string;
+  cadence: string;
+  active: boolean;
+  last_run_at: string | null;
+  created_at: string | null;
+}
+
+export interface ReportRun {
+  id: number;
+  schedule_id: number;
+  pdf_path: string;
+  generated_at: string | null;
 }
 
 export interface WhoisView {

--- a/apps/dataforseo-app/src/routes/ReportsPage.tsx
+++ b/apps/dataforseo-app/src/routes/ReportsPage.tsx
@@ -1,0 +1,288 @@
+import { useCallback, useEffect, useState } from "react";
+import toast from "react-hot-toast";
+
+import { formatError } from "../lib/errors";
+import { tauriApi, type ReportRun, type ReportSchedule } from "../lib/tauri";
+import { useProject } from "../lib/project-store";
+
+const KIND_LABELS: Record<string, string> = {
+  "daily-tracking": "Daily Keyword Tracking",
+  "weekly-audit": "Weekly Site Audit",
+  "weekly-brand": "Weekly Brand Monitor",
+};
+const CADENCE_LABELS: Record<string, string> = {
+  daily: "Daily",
+  weekly: "Weekly",
+};
+
+export default function ReportsPage() {
+  const { active: activeProject } = useProject();
+  const [schedules, setSchedules] = useState<ReportSchedule[]>([]);
+  const [runs, setRuns] = useState<Record<number, ReportRun[]>>({});
+  const [busy, setBusy] = useState(false);
+
+  // New schedule form state
+  const [kind, setKind] = useState("daily-tracking");
+  const [cadence, setCadence] = useState("daily");
+
+  const refresh = useCallback(async () => {
+    try {
+      const list = await tauriApi.reportsListSchedules();
+      setSchedules(list);
+    } catch (e) {
+      toast.error(formatError(e, "Schedules"));
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  async function loadRuns(scheduleId: number) {
+    if (runs[scheduleId]) return;
+    try {
+      const r = await tauriApi.reportsListRuns({ scheduleId });
+      setRuns((prev) => ({ ...prev, [scheduleId]: r }));
+    } catch (e) {
+      toast.error(formatError(e, "Runs"));
+    }
+  }
+
+  async function create() {
+    setBusy(true);
+    try {
+      await tauriApi.reportsCreateSchedule({
+        projectId: activeProject?.id ?? null,
+        kind,
+        cadence,
+      });
+      toast.success("Schedule created — reports will generate on next hourly tick.");
+      await refresh();
+    } catch (e) {
+      toast.error(formatError(e, "Create schedule"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function toggle(s: ReportSchedule) {
+    setBusy(true);
+    try {
+      await tauriApi.reportsToggleSchedule({ id: s.id, active: !s.active });
+      await refresh();
+    } catch (e) {
+      toast.error(formatError(e, "Toggle"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove(s: ReportSchedule) {
+    if (!confirm(`Delete schedule "${KIND_LABELS[s.kind] ?? s.kind}"?`)) return;
+    setBusy(true);
+    try {
+      await tauriApi.reportsDeleteSchedule({ id: s.id });
+      setRuns((prev) => {
+        const next = { ...prev };
+        delete next[s.id];
+        return next;
+      });
+      await refresh();
+    } catch (e) {
+      toast.error(formatError(e, "Delete"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="flex flex-col gap-6">
+      <header>
+        <h2 className="text-xl font-semibold">Scheduled PDF Reports</h2>
+        <p className="text-sm text-slate-600">
+          Configure recurring reports. The background task runs every hour and saves PDFs
+          to your Documents folder under <code>DataForSEO Reports/</code>.
+        </p>
+        {activeProject && (
+          <p className="mt-1 text-xs text-slate-500">
+            Active project: <strong>{activeProject.name}</strong> — new schedules will be
+            scoped to this project.
+          </p>
+        )}
+      </header>
+
+      {/* Create form */}
+      <div className="rounded border bg-white p-4">
+        <h3 className="mb-3 text-sm font-semibold">New Schedule</h3>
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-slate-600">Report type</span>
+            <select
+              value={kind}
+              onChange={(e) => {
+                setKind(e.target.value);
+                setCadence(e.target.value.startsWith("daily") ? "daily" : "weekly");
+              }}
+              className="rounded border px-2 py-1 text-sm"
+            >
+              {Object.entries(KIND_LABELS).map(([k, label]) => (
+                <option key={k} value={k}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-xs text-slate-600">Cadence</span>
+            <select
+              value={cadence}
+              onChange={(e) => setCadence(e.target.value)}
+              className="rounded border px-2 py-1 text-sm"
+            >
+              {Object.entries(CADENCE_LABELS).map(([c, label]) => (
+                <option key={c} value={c}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={create}
+            disabled={busy}
+            className="rounded bg-slate-800 px-3 py-1.5 text-sm text-white disabled:opacity-50"
+          >
+            + Add schedule
+          </button>
+        </div>
+      </div>
+
+      {/* Schedule list */}
+      {schedules.length === 0 ? (
+        <div className="rounded border bg-white p-6 text-center text-sm text-slate-500">
+          No schedules yet. Create one above.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {schedules.map((s) => (
+            <ScheduleCard
+              key={s.id}
+              schedule={s}
+              runs={runs[s.id]}
+              busy={busy}
+              onToggle={() => toggle(s)}
+              onDelete={() => remove(s)}
+              onExpand={() => loadRuns(s.id)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ScheduleCard({
+  schedule,
+  runs,
+  busy,
+  onToggle,
+  onDelete,
+  onExpand,
+}: {
+  schedule: ReportSchedule;
+  runs: ReportRun[] | undefined;
+  busy: boolean;
+  onToggle: () => void;
+  onDelete: () => void;
+  onExpand: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  function handleExpand() {
+    if (!expanded) onExpand();
+    setExpanded((v) => !v);
+  }
+
+  return (
+    <div className={`rounded border bg-white ${!schedule.active ? "opacity-60" : ""}`}>
+      <div className="flex items-center justify-between p-3">
+        <div>
+          <div className="text-sm font-medium">
+            {KIND_LABELS[schedule.kind] ?? schedule.kind}
+            <span className="ml-2 rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-600">
+              {CADENCE_LABELS[schedule.cadence] ?? schedule.cadence}
+            </span>
+            {!schedule.active && (
+              <span className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-xs text-amber-700">
+                Paused
+              </span>
+            )}
+          </div>
+          <div className="mt-0.5 text-xs text-slate-500">
+            {schedule.last_run_at
+              ? `Last run: ${schedule.last_run_at.slice(0, 16)}`
+              : "Never run"}
+            {" · "}
+            Schedule #{schedule.id}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={handleExpand}
+            className="rounded border px-2 py-0.5 text-xs hover:bg-slate-50"
+          >
+            {expanded ? "Hide runs" : "Show runs"}
+          </button>
+          <button
+            type="button"
+            onClick={onToggle}
+            disabled={busy}
+            className="rounded border px-2 py-0.5 text-xs disabled:opacity-50"
+          >
+            {schedule.active ? "Pause" : "Resume"}
+          </button>
+          <button
+            type="button"
+            onClick={onDelete}
+            disabled={busy}
+            className="rounded border border-red-200 px-2 py-0.5 text-xs text-red-600 disabled:opacity-50 hover:bg-red-50"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="border-t px-3 py-2">
+          {runs == null ? (
+            <div className="text-xs text-slate-500">Loading…</div>
+          ) : runs.length === 0 ? (
+            <div className="text-xs text-slate-500">No runs yet.</div>
+          ) : (
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b text-slate-500">
+                  <th className="py-1 text-left font-medium">Generated</th>
+                  <th className="py-1 text-left font-medium">File</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((r) => (
+                  <tr key={r.id} className="border-b last:border-0">
+                    <td className="py-1 pr-4 tabular-nums">
+                      {r.generated_at?.slice(0, 16) ?? "—"}
+                    </td>
+                    <td className="py-1 font-mono text-slate-700 break-all">
+                      {r.pdf_path}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Migration v0008** — `report_schedules` + `report_runs` tables (kind, cadence, active flag, last_run_at, PDF path per run)
- **`store/reports.rs`** — full CRUD: list/create/toggle/delete schedules, due-schedule query, record runs, mark ran
- **`tasks/reporter.rs`** — 1 h background task; for each due schedule fetches live data from DB, renders an A4 PDF via `printpdf 0.7` (pure-Rust, built-in Helvetica/HelveticaBold, no system font deps), saves to `<Documents>/DataForSEO Reports/`, records in `report_runs`
- **`commands/reports.rs`** — five Tauri commands registered in `invoke_handler`
- **`src/routes/ReportsPage.tsx`** — schedule list + create form (type × cadence dropdowns) + expandable per-schedule run history showing the PDF path
- `App.tsx`: Reports nav entry + `/reports` route; `tauri.ts`: mirrored `ReportSchedule` / `ReportRun` types + five `tauriApi.*` shims

Three report kinds supported out of the box:
| Kind | Data source | Cadence |
|------|-------------|---------|
| `daily-tracking` | `tracking::list_with_ranks` | daily |
| `weekly-audit` | placeholder (points user to Audit tab) | weekly |
| `weekly-brand` | placeholder (points user to Brand tab) | weekly |

## Test plan

- [ ] TypeScript: `npx tsc --noEmit` → clean (verified locally)
- [ ] Frontend tests: `npx vitest run` → 63/63 pass (verified locally)
- [ ] Rust: `cargo check --no-default-features` passes on CI (disk-space limit blocks local bundled DuckDB rebuild)
- [ ] Create a schedule in the UI → confirm it appears in the list
- [ ] Pause / resume toggle works
- [ ] Expand run history (empty until next hourly tick)
- [ ] Delete removes the schedule and its runs

https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR

---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_