### PR TITLE
feat(dataforseo-app): C4 — ExportMenu rollout to data tabs

### DIFF
--- a/apps/dataforseo-app/src/routes/audit/AuditRunDetail.tsx
+++ b/apps/dataforseo-app/src/routes/audit/AuditRunDetail.tsx
@@ -13,7 +13,7 @@ const PAGE_COLUMNS: ColumnDef<AuditPage, unknown>[] = [
   { id: "onpage_score", header: "Score", accessorKey: "onpage_score" },
   { id: "title", header: "Title", accessorKey: "title" },
   { id: "h1", header: "H1", accessorKey: "h1" },
-  { id: "word_count", header: "Words", accessorKey: "word_count" },
+  { id: "word_count", header: "Words", accessorKey: "plain_text_word_count" },
 ];
 
 interface Props {

--- a/apps/dataforseo-app/src/routes/audit/AuditRunDetail.tsx
+++ b/apps/dataforseo-app/src/routes/audit/AuditRunDetail.tsx
@@ -1,9 +1,20 @@
+import type { ColumnDef } from "@tanstack/react-table";
 import { useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import { formatError } from "../../lib/errors";
 
+import ExportMenu from "../../components/ExportMenu";
 import { tauriApi, type AuditPage, type AuditRun } from "../../lib/tauri";
+
+const PAGE_COLUMNS: ColumnDef<AuditPage, unknown>[] = [
+  { id: "url", header: "URL", accessorKey: "url" },
+  { id: "status_code", header: "HTTP", accessorKey: "status_code" },
+  { id: "onpage_score", header: "Score", accessorKey: "onpage_score" },
+  { id: "title", header: "Title", accessorKey: "title" },
+  { id: "h1", header: "H1", accessorKey: "h1" },
+  { id: "word_count", header: "Words", accessorKey: "word_count" },
+];
 
 interface Props {
   run: AuditRun;
@@ -115,9 +126,18 @@ export default function AuditRunDetail({ run }: Props) {
         </div>
       )}
 
-      <h4 className="mt-2 text-sm font-semibold">
-        Pages {pages.length > 0 && `(showing ${pages.length} weakest)`}
-      </h4>
+      <div className="mt-2 flex items-center justify-between">
+        <h4 className="text-sm font-semibold">
+          Pages {pages.length > 0 && `(showing ${pages.length} weakest)`}
+        </h4>
+        {pages.length > 0 && (
+          <ExportMenu
+            filenameStem={`audit-${run.id}-pages`}
+            rows={pages}
+            columns={PAGE_COLUMNS}
+          />
+        )}
+      </div>
       {loading ? (
         <p className="text-xs text-slate-500">Loading…</p>
       ) : pages.length === 0 ? (

--- a/apps/dataforseo-app/src/routes/keywords/TrendsTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/TrendsTab.tsx
@@ -114,13 +114,16 @@ export default function TrendsTab() {
   // ExportMenu columns are derived from the actual keywords queried, plus
   // the leading date column. CSV export is the most useful artifact since
   // it's a time series — pastes straight into a spreadsheet.
+  //
+  // accessorFn (not accessorKey) so a keyword like "example.com" doesn't
+  // get treated as a nested path by TanStack Table.
   const exportColumns = useMemo<ColumnDef<ChartPoint, unknown>[]>(
     () => [
       { id: "date", header: "Date", accessorKey: "date" },
       ...(view?.keywords.map((kw) => ({
         id: kw,
         header: kw,
-        accessorKey: kw,
+        accessorFn: (row: ChartPoint) => row[kw],
       })) ?? []),
     ],
     [view?.keywords],

--- a/apps/dataforseo-app/src/routes/keywords/TrendsTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/TrendsTab.tsx
@@ -1,3 +1,4 @@
+import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
@@ -15,6 +16,7 @@ import {
 
 import CacheBadge from "../../components/CacheBadge";
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import { DEFAULT_LANGUAGE, DEFAULT_LOCATION } from "../../lib/constants";
 import { formatUsd } from "../../lib/format";
 import { tauriApi, type TrendsView } from "../../lib/tauri";
@@ -109,6 +111,21 @@ export default function TrendsTab() {
     [view],
   );
 
+  // ExportMenu columns are derived from the actual keywords queried, plus
+  // the leading date column. CSV export is the most useful artifact since
+  // it's a time series — pastes straight into a spreadsheet.
+  const exportColumns = useMemo<ColumnDef<ChartPoint, unknown>[]>(
+    () => [
+      { id: "date", header: "Date", accessorKey: "date" },
+      ...(view?.keywords.map((kw) => ({
+        id: kw,
+        header: kw,
+        accessorKey: kw,
+      })) ?? []),
+    ],
+    [view?.keywords],
+  );
+
   return (
     <div className="flex flex-col gap-6">
       <p className="text-sm text-slate-600">
@@ -164,6 +181,15 @@ export default function TrendsTab() {
           <span>
             actual {formatUsd(view.cost_usd)} · estimated {formatUsd(view.estimated_usd)}
           </span>
+          {chartData && chartData.length > 0 && (
+            <span className="ml-auto">
+              <ExportMenu
+                filenameStem={`trends-${view.keywords.join("-")}`}
+                rows={chartData}
+                columns={exportColumns}
+              />
+            </span>
+          )}
         </div>
       )}
 

--- a/apps/dataforseo-app/src/routes/serp/AutocompleteTab.tsx
+++ b/apps/dataforseo-app/src/routes/serp/AutocompleteTab.tsx
@@ -1,12 +1,14 @@
-import { useState } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
 import { formatError } from "../../lib/errors";
 
 import CostPreview from "../../components/CostPreview";
+import ExportMenu from "../../components/ExportMenu";
 import { DEFAULT_LANGUAGE, DEFAULT_LOCATION } from "../../lib/constants";
 import { formatUsd } from "../../lib/format";
-import { tauriApi, type AutocompleteView } from "../../lib/tauri";
+import { tauriApi, type AutocompleteSuggestion, type AutocompleteView } from "../../lib/tauri";
 
 export default function AutocompleteTab() {
   const [keyword, setKeyword] = useState("");
@@ -14,6 +16,15 @@ export default function AutocompleteTab() {
   const [view, setView] = useState<AutocompleteView | null>(null);
 
   const trimmed = keyword.trim();
+
+  const exportColumns = useMemo<ColumnDef<AutocompleteSuggestion, unknown>[]>(
+    () => [
+      { id: "rank_absolute", header: "Rank", accessorKey: "rank_absolute" },
+      { id: "suggestion", header: "Suggestion", accessorKey: "suggestion" },
+      { id: "relevance", header: "Relevance", accessorKey: "relevance" },
+    ],
+    [],
+  );
 
   async function onRun() {
     if (!trimmed) return;
@@ -74,10 +85,17 @@ export default function AutocompleteTab() {
       {view ? (
         view.items.length > 0 ? (
           <div className="flex flex-col gap-2">
-            <p className="text-xs text-slate-500">
-              {view.items.length} suggestions for &ldquo;{view.keyword}&rdquo; ·{" "}
-              {formatUsd(view.cost_usd)}
-            </p>
+            <div className="flex items-center justify-between text-xs text-slate-500">
+              <span>
+                {view.items.length} suggestions for &ldquo;{view.keyword}&rdquo; ·{" "}
+                {formatUsd(view.cost_usd)}
+              </span>
+              <ExportMenu
+                filenameStem={`autocomplete-${view.keyword}`}
+                rows={view.items}
+                columns={exportColumns}
+              />
+            </div>
             <ol className="grid grid-cols-1 gap-1 sm:grid-cols-2">
               {view.items.map((s, i) => (
                 <li

--- a/apps/dataforseo-app/src/routes/usage/AiTab.tsx
+++ b/apps/dataforseo-app/src/routes/usage/AiTab.tsx
@@ -1,3 +1,4 @@
+import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
@@ -12,6 +13,7 @@ import {
   YAxis,
 } from "recharts";
 
+import ExportMenu from "../../components/ExportMenu";
 import { formatCount, formatUsd } from "../../lib/format";
 import {
   tauriApi,
@@ -19,6 +21,17 @@ import {
   type AiUsageSummary,
 } from "../../lib/tauri";
 import Stat from "./Stat";
+
+const AI_CALL_COLUMNS: ColumnDef<AiCallRow, unknown>[] = [
+  { id: "ts", header: "Time", accessorKey: "ts" },
+  { id: "provider", header: "Provider", accessorKey: "provider" },
+  { id: "model", header: "Model", accessorKey: "model" },
+  { id: "purpose", header: "Purpose", accessorKey: "purpose" },
+  { id: "input_tokens", header: "Input tokens", accessorKey: "input_tokens" },
+  { id: "output_tokens", header: "Output tokens", accessorKey: "output_tokens" },
+  { id: "cost_usd", header: "Cost USD", accessorKey: "cost_usd" },
+  { id: "duration_ms", header: "Duration ms", accessorKey: "duration_ms" },
+];
 
 const RANGE_OPTIONS = [
   { value: 7, label: "7 days" },
@@ -144,9 +157,16 @@ export default function AiTab() {
       </div>
 
       <div className="rounded border bg-white">
-        <h3 className="border-b px-3 py-2 text-sm font-medium text-slate-700">
-          Recent AI calls (last 50)
-        </h3>
+        <div className="flex items-center justify-between border-b px-3 py-2">
+          <h3 className="text-sm font-medium text-slate-700">Recent AI calls (last 50)</h3>
+          {recent != null && recent.length > 0 && (
+            <ExportMenu
+              filenameStem="usage-ai-calls"
+              rows={recent}
+              columns={AI_CALL_COLUMNS}
+            />
+          )}
+        </div>
         {recent == null || recent.length === 0 ? (
           <div className="p-8 text-center text-sm text-slate-500">No AI calls yet.</div>
         ) : (

--- a/apps/dataforseo-app/src/routes/usage/DataforseoTab.tsx
+++ b/apps/dataforseo-app/src/routes/usage/DataforseoTab.tsx
@@ -1,3 +1,4 @@
+import type { ColumnDef } from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 
@@ -12,6 +13,7 @@ import {
   YAxis,
 } from "recharts";
 
+import ExportMenu from "../../components/ExportMenu";
 import { formatUsd } from "../../lib/format";
 import {
   tauriApi,
@@ -20,6 +22,16 @@ import {
 } from "../../lib/tauri";
 import BudgetCard from "./BudgetCard";
 import Stat from "./Stat";
+
+const CALL_COLUMNS: ColumnDef<CallLogRow, unknown>[] = [
+  { id: "ts", header: "Time", accessorKey: "ts" },
+  { id: "endpoint", header: "Endpoint", accessorKey: "endpoint" },
+  { id: "mode", header: "Mode", accessorKey: "mode" },
+  { id: "cost_usd", header: "Cost USD", accessorKey: "cost_usd" },
+  { id: "estimated_usd", header: "Estimated USD", accessorKey: "estimated_usd" },
+  { id: "request_size", header: "Items", accessorKey: "request_size" },
+  { id: "duration_ms", header: "Duration ms", accessorKey: "duration_ms" },
+];
 
 const RANGE_OPTIONS = [
   { value: 7, label: "7 days" },
@@ -153,9 +165,16 @@ export default function DataforseoTab() {
       </div>
 
       <div className="rounded border bg-white">
-        <h3 className="border-b px-3 py-2 text-sm font-medium text-slate-700">
-          Recent calls (last 50)
-        </h3>
+        <div className="flex items-center justify-between border-b px-3 py-2">
+          <h3 className="text-sm font-medium text-slate-700">Recent calls (last 50)</h3>
+          {recent != null && recent.length > 0 && (
+            <ExportMenu
+              filenameStem="usage-dataforseo-calls"
+              rows={recent}
+              columns={CALL_COLUMNS}
+            />
+          )}
+        </div>
         {recent == null || recent.length === 0 ? (
           <div className="p-8 text-center text-sm text-slate-500">No calls yet.</div>
         ) : (


### PR DESCRIPTION
## Summary

Adds CSV/JSON export to the data tabs that didn't already have it. Most SERP/keyword tabs share `SerpKeywordTab` / `SeedTab` (which already have `ExportMenu`); this PR targets the five genuinely-custom tabs:

| Tab | Exported columns |
|---|---|
| `serp/AutocompleteTab` | rank · suggestion · relevance |
| `keywords/TrendsTab` | date + one column per queried keyword (time series CSV) |
| `usage/DataforseoTab` | ts · endpoint · mode · cost · est. · items · ms |
| `usage/AiTab` | ts · provider · model · purpose · tokens · cost · ms |
| `audit/AuditRunDetail` | url · http · score · title · h1 · words |

Skipped intentionally: `KeywordOverviewTab` (single-row tile summary), `BulkTab` (submission form, not a results page).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` 63/63 pass
- [ ] Click Export on each tab and verify the CSV opens correctly
- [ ] Verify Trends CSV has one column per queried keyword

https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR

---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_