### PR TITLE
test(dataforseo-app): D1 round-3 — ResultsTable + BudgetCard tests

### DIFF
--- a/apps/dataforseo-app/src/components/ResultsTable.test.tsx
+++ b/apps/dataforseo-app/src/components/ResultsTable.test.tsx
@@ -67,9 +67,11 @@ describe("ResultsTable", () => {
     render(<ResultsTable data={ROWS} columns={COLS} />);
     const scoreHeader = screen.getByText("Score");
     fireEvent.click(scoreHeader);
-    // First click on numeric column → descending → ▼
-    expect(scoreHeader.parentElement?.textContent).toMatch(/▼/);
+    // First click on numeric column → descending → ▼.
+    // Asserting on the <th> directly (not the row) so a glyph that
+    // accidentally rendered in a sibling column wouldn't pass.
+    expect(scoreHeader.textContent).toMatch(/▼/);
     fireEvent.click(scoreHeader);
-    expect(scoreHeader.parentElement?.textContent).toMatch(/▲/);
+    expect(scoreHeader.textContent).toMatch(/▲/);
   });
 });

--- a/apps/dataforseo-app/src/components/ResultsTable.test.tsx
+++ b/apps/dataforseo-app/src/components/ResultsTable.test.tsx
@@ -1,0 +1,75 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ResultsTable from "./ResultsTable";
+
+interface Row {
+  name: string;
+  score: number;
+}
+
+const COLS: ColumnDef<Row, unknown>[] = [
+  { id: "name", header: "Name", accessorKey: "name" },
+  { id: "score", header: "Score", accessorKey: "score" },
+];
+
+const ROWS: Row[] = [
+  { name: "alpha", score: 30 },
+  { name: "beta", score: 10 },
+  { name: "gamma", score: 20 },
+];
+
+describe("ResultsTable", () => {
+  it("renders the empty-state message when data is empty", () => {
+    render(<ResultsTable data={[]} columns={COLS} emptyMessage="Nothing here." />);
+    expect(screen.getByText("Nothing here.")).toBeTruthy();
+  });
+
+  it("falls back to the default empty message", () => {
+    render(<ResultsTable data={[]} columns={COLS} />);
+    expect(screen.getByText(/no results yet/i)).toBeTruthy();
+  });
+
+  it("renders one row per data item", () => {
+    render(<ResultsTable data={ROWS} columns={COLS} />);
+    // 1 header row + 3 data rows = 4 total
+    expect(screen.getAllByRole("row")).toHaveLength(4);
+    expect(screen.getByText("alpha")).toBeTruthy();
+    expect(screen.getByText("beta")).toBeTruthy();
+    expect(screen.getByText("gamma")).toBeTruthy();
+  });
+
+  it("toggles sort order on repeated header clicks", () => {
+    render(<ResultsTable data={ROWS} columns={COLS} />);
+    const scoreHeader = screen.getByText("Score");
+
+    function getNamesInOrder(): string[] {
+      // First row is the header — slice(1) skips it.
+      return screen
+        .getAllByRole("row")
+        .slice(1)
+        .map((r) => r.querySelector("td")!.textContent ?? "");
+    }
+    // Initial unsorted order matches the input data.
+    expect(getNamesInOrder()).toEqual(["alpha", "beta", "gamma"]);
+
+    // TanStack Table's first click on a numeric column sorts descending.
+    fireEvent.click(scoreHeader);
+    expect(getNamesInOrder()).toEqual(["alpha", "gamma", "beta"]); // 30, 20, 10
+
+    // Second click flips to ascending.
+    fireEvent.click(scoreHeader);
+    expect(getNamesInOrder()).toEqual(["beta", "gamma", "alpha"]); // 10, 20, 30
+  });
+
+  it("indicates the active sort direction with an arrow glyph", () => {
+    render(<ResultsTable data={ROWS} columns={COLS} />);
+    const scoreHeader = screen.getByText("Score");
+    fireEvent.click(scoreHeader);
+    // First click on numeric column → descending → ▼
+    expect(scoreHeader.parentElement?.textContent).toMatch(/▼/);
+    fireEvent.click(scoreHeader);
+    expect(scoreHeader.parentElement?.textContent).toMatch(/▲/);
+  });
+});

--- a/apps/dataforseo-app/src/routes/usage/BudgetCard.test.tsx
+++ b/apps/dataforseo-app/src/routes/usage/BudgetCard.test.tsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { Toaster } from "react-hot-toast";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import BudgetCard from "./BudgetCard";
+
+const getBudgetStatus = vi.fn();
+const setBudget = vi.fn();
+const clearBudget = vi.fn();
+
+vi.mock("../../lib/tauri", () => ({
+  tauriApi: {
+    getBudgetStatus: (...args: unknown[]) => getBudgetStatus(...args),
+    setBudget: (...args: unknown[]) => setBudget(...args),
+    clearBudget: (...args: unknown[]) => clearBudget(...args),
+  },
+}));
+
+beforeEach(() => {
+  getBudgetStatus.mockReset();
+  setBudget.mockReset();
+  clearBudget.mockReset();
+});
+
+function renderCard() {
+  return render(
+    <>
+      <BudgetCard />
+      <Toaster />
+    </>,
+  );
+}
+
+describe("BudgetCard", () => {
+  it("renders 'no budget set' when limit is null", async () => {
+    getBudgetStatus.mockResolvedValue({
+      period: "daily",
+      limit_usd: null,
+      alert_at_pct: null,
+      spent_usd: 0.42,
+      used_pct: null,
+      state: "no_budget",
+    });
+    renderCard();
+    expect(await screen.findByText(/No daily budget set/)).toBeTruthy();
+  });
+
+  it("renders the spent / limit ratio when a budget exists", async () => {
+    getBudgetStatus.mockResolvedValue({
+      period: "daily",
+      limit_usd: 5,
+      alert_at_pct: 80,
+      spent_usd: 2.5,
+      used_pct: 50,
+      state: "ok",
+    });
+    renderCard();
+    // Spent / limit summary line.
+    await waitFor(() => {
+      expect(screen.getByText(/\$2\.5000.*\$5\.0000/)).toBeTruthy();
+    });
+    expect(screen.getByText("ok")).toBeTruthy();
+    expect(screen.getByText(/50%/)).toBeTruthy();
+  });
+
+  it("colors the alert state with amber", async () => {
+    getBudgetStatus.mockResolvedValue({
+      period: "daily",
+      limit_usd: 5,
+      alert_at_pct: 80,
+      spent_usd: 4.2,
+      used_pct: 84,
+      state: "alert",
+    });
+    const { container } = renderCard();
+    await waitFor(() => expect(screen.getByText("alert")).toBeTruthy());
+    // The status banner is the only element with the amber colour class.
+    expect(container.querySelector(".bg-amber-100")).not.toBeNull();
+  });
+
+  it("colors the exceeded state with red", async () => {
+    getBudgetStatus.mockResolvedValue({
+      period: "daily",
+      limit_usd: 5,
+      alert_at_pct: 80,
+      spent_usd: 6,
+      used_pct: 120,
+      state: "exceeded",
+    });
+    const { container } = renderCard();
+    await waitFor(() => expect(screen.getByText("exceeded")).toBeTruthy());
+    expect(container.querySelector(".bg-red-100")).not.toBeNull();
+  });
+
+  it("renders the period switcher with Daily and Monthly", async () => {
+    getBudgetStatus.mockResolvedValue({
+      period: "daily",
+      limit_usd: null,
+      alert_at_pct: null,
+      spent_usd: 0,
+      used_pct: null,
+      state: "no_budget",
+    });
+    renderCard();
+    expect(screen.getByText("Daily")).toBeTruthy();
+    expect(screen.getByText("Monthly")).toBeTruthy();
+  });
+
+  it("does not crash when the status fetch rejects", async () => {
+    getBudgetStatus.mockRejectedValue(new Error("network"));
+    renderCard();
+    // Save / Limit input still renders even though no status came back.
+    expect(screen.getByText(/Limit/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Two more component test files for the heavily-used UI primitives that didn't have any.

**ResultsTable** (5 tests):
- Empty-state: default + custom message
- One header row + N data rows render correctly
- Header click toggles sort order (TanStack Table starts numeric columns descending)
- Arrow glyph (▼/▲) reflects active sort direction

**BudgetCard** (6 tests):
- "No budget set" branch (`limit_usd: null`)
- Spent / limit ratio + state badge for `ok` / `alert` / `exceeded`
- Amber and red colour classes for the corresponding states
- Period switcher renders both Daily and Monthly
- Non-fatal: status fetch rejection doesn't crash the form

**Suite total**: 12 files / 74 tests (was 10 / 63 before this PR).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` 74/74 pass
- [ ] Visual smoke test: BudgetCard renders correctly in `/usage`

https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR

---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_