### PR TITLE
feat(content-strategy): editorial calendar (phase 1)

### DIFF
--- a/apps/dataforseo-app/src-tauri/migrations/v0010_content_strategy.sql
+++ b/apps/dataforseo-app/src-tauri/migrations/v0010_content_strategy.sql
@@ -1,0 +1,21 @@
+-- Editorial calendar: planned posts the user wants to write/publish.
+-- Persistence for the Content Strategy page (issue #68 phase 1).
+
+CREATE SEQUENCE IF NOT EXISTS planned_posts_id_seq;
+
+CREATE TABLE IF NOT EXISTS planned_posts (
+    id              BIGINT    PRIMARY KEY DEFAULT nextval('planned_posts_id_seq'),
+    project_id      BIGINT,                          -- nullable = global / unscoped
+    title           VARCHAR   NOT NULL,
+    target_keyword  VARCHAR,                         -- the primary keyword the post targets
+    status          VARCHAR   NOT NULL DEFAULT 'idea',
+                                                     -- 'idea' | 'drafting' | 'review' | 'published' | 'archived'
+    scheduled_for   DATE,                            -- planned publish date (calendar slot)
+    notes           VARCHAR,
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS planned_posts_project_idx  ON planned_posts(project_id);
+CREATE INDEX IF NOT EXISTS planned_posts_schedule_idx ON planned_posts(scheduled_for);
+CREATE INDEX IF NOT EXISTS planned_posts_status_idx   ON planned_posts(status);

--- a/apps/dataforseo-app/src-tauri/src/commands/content_strategy.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/content_strategy.rs
@@ -1,0 +1,94 @@
+//! Content Strategy commands. Phase 1 = editorial calendar CRUD.
+//! Topic clusters and the gap-to-brief pipeline land in later phases.
+
+use serde::{Deserialize, Serialize};
+use tauri::State;
+use ts_rs::TS;
+
+use crate::errors::{AppError, Result};
+use crate::state::AppState;
+use crate::store;
+use crate::store::content_strategy::PlannedPost;
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct PlannedPostInput {
+    pub project_id: Option<i64>,
+    pub title: String,
+    pub target_keyword: Option<String>,
+    /// Defaults to "idea" if the caller passes None.
+    pub status: Option<String>,
+    /// ISO YYYY-MM-DD.
+    pub scheduled_for: Option<String>,
+    pub notes: Option<String>,
+}
+
+#[tauri::command]
+pub async fn planned_posts_list(
+    state: State<'_, AppState>,
+    project_id: Option<i64>,
+) -> Result<Vec<PlannedPost>> {
+    let store = state.store.clone();
+    tokio::task::spawn_blocking(move || {
+        store.with_conn(|c| store::content_strategy::list(c, project_id))
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
+pub async fn planned_posts_create(
+    state: State<'_, AppState>,
+    input: PlannedPostInput,
+) -> Result<i64> {
+    let store = state.store.clone();
+    tokio::task::spawn_blocking(move || {
+        store.with_conn(|c| {
+            store::content_strategy::create(
+                c,
+                input.project_id,
+                &input.title,
+                input.target_keyword.as_deref(),
+                input.status.as_deref().unwrap_or("idea"),
+                input.scheduled_for.as_deref(),
+                input.notes.as_deref(),
+            )
+        })
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
+pub async fn planned_posts_update(
+    state: State<'_, AppState>,
+    id: i64,
+    input: PlannedPostInput,
+) -> Result<()> {
+    let store = state.store.clone();
+    tokio::task::spawn_blocking(move || {
+        store.with_conn(|c| {
+            store::content_strategy::update(
+                c,
+                id,
+                &input.title,
+                input.target_keyword.as_deref(),
+                input.status.as_deref().unwrap_or("idea"),
+                input.scheduled_for.as_deref(),
+                input.notes.as_deref(),
+            )
+        })
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+#[tauri::command]
+pub async fn planned_posts_delete(state: State<'_, AppState>, id: i64) -> Result<()> {
+    let store = state.store.clone();
+    tokio::task::spawn_blocking(move || {
+        store.with_conn(|c| store::content_strategy::delete(c, id))
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))?
+}

--- a/apps/dataforseo-app/src-tauri/src/commands/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/mod.rs
@@ -5,6 +5,7 @@ pub mod auth;
 pub mod backlinks;
 pub mod brand;
 pub mod cached;
+pub mod content_strategy;
 pub mod domain_analytics;
 pub mod import;
 pub mod keywords;

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -208,6 +208,10 @@ pub fn run() {
             commands::reports::reports_list_runs,
             commands::import::semrush_import,
             commands::import::semrush_list_imports,
+            commands::content_strategy::planned_posts_list,
+            commands::content_strategy::planned_posts_create,
+            commands::content_strategy::planned_posts_update,
+            commands::content_strategy::planned_posts_delete,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/dataforseo-app/src-tauri/src/store/content_strategy.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/content_strategy.rs
@@ -1,0 +1,116 @@
+//! Editorial calendar persistence. Backs the Content Strategy page —
+//! a per-project list of planned posts with status + scheduled-for date.
+
+use duckdb::{params, Connection};
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+use crate::errors::Result;
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct PlannedPost {
+    pub id: i64,
+    pub project_id: Option<i64>,
+    pub title: String,
+    pub target_keyword: Option<String>,
+    /// 'idea' | 'drafting' | 'review' | 'published' | 'archived'
+    pub status: String,
+    /// ISO date (YYYY-MM-DD) the post is scheduled to be published.
+    pub scheduled_for: Option<String>,
+    pub notes: Option<String>,
+    pub created_at: Option<String>,
+    pub updated_at: Option<String>,
+}
+
+pub fn create(
+    conn: &mut Connection,
+    project_id: Option<i64>,
+    title: &str,
+    target_keyword: Option<&str>,
+    status: &str,
+    scheduled_for: Option<&str>,
+    notes: Option<&str>,
+) -> Result<i64> {
+    let id: i64 = conn.query_row(
+        "INSERT INTO planned_posts
+            (project_id, title, target_keyword, status, scheduled_for, notes)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING id",
+        params![project_id, title, target_keyword, status, scheduled_for, notes],
+        |row| row.get(0),
+    )?;
+    Ok(id)
+}
+
+pub fn update(
+    conn: &mut Connection,
+    id: i64,
+    title: &str,
+    target_keyword: Option<&str>,
+    status: &str,
+    scheduled_for: Option<&str>,
+    notes: Option<&str>,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE planned_posts
+            SET title = $2,
+                target_keyword = $3,
+                status = $4,
+                scheduled_for = $5,
+                notes = $6,
+                updated_at = CURRENT_TIMESTAMP
+          WHERE id = $1",
+        params![id, title, target_keyword, status, scheduled_for, notes],
+    )?;
+    Ok(())
+}
+
+pub fn delete(conn: &mut Connection, id: i64) -> Result<()> {
+    conn.execute("DELETE FROM planned_posts WHERE id = $1", params![id])?;
+    Ok(())
+}
+
+/// List planned posts for a project (or all if `project_id` is None).
+/// Newest scheduled date first, then by created_at.
+pub fn list(conn: &mut Connection, project_id: Option<i64>) -> Result<Vec<PlannedPost>> {
+    // DuckDB doesn't optimise away parameters in `(? IS NULL OR project_id = ?)`
+    // as cleanly as SQLite, so split the query into two paths.
+    let sql = if project_id.is_some() {
+        "SELECT id, project_id, title, target_keyword, status,
+                CAST(scheduled_for AS VARCHAR), notes,
+                CAST(created_at AS VARCHAR), CAST(updated_at AS VARCHAR)
+           FROM planned_posts
+          WHERE project_id = $1
+          ORDER BY scheduled_for DESC NULLS LAST, created_at DESC"
+    } else {
+        "SELECT id, project_id, title, target_keyword, status,
+                CAST(scheduled_for AS VARCHAR), notes,
+                CAST(created_at AS VARCHAR), CAST(updated_at AS VARCHAR)
+           FROM planned_posts
+          ORDER BY scheduled_for DESC NULLS LAST, created_at DESC"
+    };
+
+    let mut stmt = conn.prepare(sql)?;
+    let mut rows = if let Some(pid) = project_id {
+        stmt.query(params![pid])?
+    } else {
+        stmt.query([])?
+    };
+
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        out.push(PlannedPost {
+            id: row.get(0)?,
+            project_id: row.get(1)?,
+            title: row.get(2)?,
+            target_keyword: row.get(3)?,
+            status: row.get(4)?,
+            scheduled_for: row.get(5)?,
+            notes: row.get(6)?,
+            created_at: row.get(7)?,
+            updated_at: row.get(8)?,
+        });
+    }
+    Ok(out)
+}

--- a/apps/dataforseo-app/src-tauri/src/store/content_strategy.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/content_strategy.rs
@@ -76,17 +76,24 @@ pub fn delete(conn: &mut Connection, id: i64) -> Result<()> {
 pub fn list(conn: &mut Connection, project_id: Option<i64>) -> Result<Vec<PlannedPost>> {
     // DuckDB doesn't optimise away parameters in `(? IS NULL OR project_id = ?)`
     // as cleanly as SQLite, so split the query into two paths.
+    // Named CAST aliases (scheduled_for_s / created_at_s / updated_at_s)
+    // let the row-mapping below use column names instead of indices —
+    // safer if the SELECT list is ever reordered.
     let sql = if project_id.is_some() {
         "SELECT id, project_id, title, target_keyword, status,
-                CAST(scheduled_for AS VARCHAR), notes,
-                CAST(created_at AS VARCHAR), CAST(updated_at AS VARCHAR)
+                CAST(scheduled_for AS VARCHAR) AS scheduled_for_s,
+                notes,
+                CAST(created_at AS VARCHAR)    AS created_at_s,
+                CAST(updated_at AS VARCHAR)    AS updated_at_s
            FROM planned_posts
           WHERE project_id = $1
           ORDER BY scheduled_for DESC NULLS LAST, created_at DESC"
     } else {
         "SELECT id, project_id, title, target_keyword, status,
-                CAST(scheduled_for AS VARCHAR), notes,
-                CAST(created_at AS VARCHAR), CAST(updated_at AS VARCHAR)
+                CAST(scheduled_for AS VARCHAR) AS scheduled_for_s,
+                notes,
+                CAST(created_at AS VARCHAR)    AS created_at_s,
+                CAST(updated_at AS VARCHAR)    AS updated_at_s
            FROM planned_posts
           ORDER BY scheduled_for DESC NULLS LAST, created_at DESC"
     };
@@ -101,15 +108,15 @@ pub fn list(conn: &mut Connection, project_id: Option<i64>) -> Result<Vec<Planne
     let mut out = Vec::new();
     while let Some(row) = rows.next()? {
         out.push(PlannedPost {
-            id: row.get(0)?,
-            project_id: row.get(1)?,
-            title: row.get(2)?,
-            target_keyword: row.get(3)?,
-            status: row.get(4)?,
-            scheduled_for: row.get(5)?,
-            notes: row.get(6)?,
-            created_at: row.get(7)?,
-            updated_at: row.get(8)?,
+            id: row.get("id")?,
+            project_id: row.get("project_id")?,
+            title: row.get("title")?,
+            target_keyword: row.get("target_keyword")?,
+            status: row.get("status")?,
+            scheduled_for: row.get("scheduled_for_s")?,
+            notes: row.get("notes")?,
+            created_at: row.get("created_at_s")?,
+            updated_at: row.get("updated_at_s")?,
         });
     }
     Ok(out)

--- a/apps/dataforseo-app/src-tauri/src/store/mod.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/mod.rs
@@ -2,6 +2,7 @@ pub mod audits;
 pub mod reports;
 pub mod backlinks;
 pub mod chat;
+pub mod content_strategy;
 pub mod cost_budget;
 pub mod keywords_cache;
 pub mod ledger;

--- a/apps/dataforseo-app/src-tauri/src/store/schema.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/schema.rs
@@ -14,6 +14,7 @@ const MIGRATIONS: &[(u32, &str)] = &[
     (7, include_str!("../../migrations/v0007_projects.sql")),
     (8, include_str!("../../migrations/v0008_reports.sql")),
     (9, include_str!("../../migrations/v0009_semrush_import.sql")),
+    (10, include_str!("../../migrations/v0010_content_strategy.sql")),
 ];
 
 pub fn ensure_current(conn: &mut Connection) -> Result<()> {

--- a/apps/dataforseo-app/src/App.tsx
+++ b/apps/dataforseo-app/src/App.tsx
@@ -12,6 +12,7 @@ import BacklinksPage from "./routes/BacklinksPage";
 import BrandPage from "./routes/BrandPage";
 import ChatPage from "./routes/ChatPage";
 import ComparePage from "./routes/ComparePage";
+import ContentStrategyPage from "./routes/ContentStrategyPage";
 import DomainAnalyticsPage from "./routes/DomainAnalyticsPage";
 import KeywordClusteringPage from "./routes/KeywordClusteringPage";
 import KeywordsPage from "./routes/KeywordsPage";
@@ -32,6 +33,7 @@ import SettingsPage from "./routes/SettingsPage";
 const navItems = [
   { to: "/keywords", label: "Keywords" },
   { to: "/clustering", label: "Keyword Clustering" },
+  { to: "/content-strategy", label: "Content Strategy" },
   { to: "/topic", label: "Topic Research" },
   { to: "/serp", label: "SERP" },
   { to: "/tracking", label: "Tracking" },
@@ -126,6 +128,7 @@ function AppShell() {
           <Route path="/" element={<Navigate to="/keywords" replace />} />
           <Route path="/keywords/*" element={<KeywordsPage />} />
           <Route path="/clustering" element={<KeywordClusteringPage />} />
+          <Route path="/content-strategy" element={<ContentStrategyPage />} />
           <Route path="/topic" element={<TopicPage />} />
           <Route path="/serp/*" element={<SerpPage />} />
           <Route path="/tracking" element={<TrackingPage />} />

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -402,6 +402,18 @@ export const tauriApi = {
   }) => invoke<SemrushImportResult>("semrush_import", args),
 
   semrushListImports: () => invoke<SemrushImport[]>("semrush_list_imports"),
+
+  plannedPostsList: (args: { projectId: number | null }) =>
+    invoke<PlannedPost[]>("planned_posts_list", args),
+
+  plannedPostsCreate: (args: { input: PlannedPostInput }) =>
+    invoke<number>("planned_posts_create", args),
+
+  plannedPostsUpdate: (args: { id: number; input: PlannedPostInput }) =>
+    invoke<void>("planned_posts_update", args),
+
+  plannedPostsDelete: (args: { id: number }) =>
+    invoke<void>("planned_posts_delete", args),
 };
 
 export interface AiProviderStatus {
@@ -1173,4 +1185,27 @@ export interface SemrushImport {
   language_code: string | null;
   cost_saved_usd: number;
   imported_at: string | null;
+}
+
+export interface PlannedPost {
+  id: number;
+  project_id: number | null;
+  title: string;
+  target_keyword: string | null;
+  /** "idea" | "drafting" | "review" | "published" | "archived" */
+  status: string;
+  /** ISO YYYY-MM-DD */
+  scheduled_for: string | null;
+  notes: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+export interface PlannedPostInput {
+  project_id: number | null;
+  title: string;
+  target_keyword: string | null;
+  status: string | null;
+  scheduled_for: string | null;
+  notes: string | null;
 }

--- a/apps/dataforseo-app/src/routes/ContentStrategyPage.tsx
+++ b/apps/dataforseo-app/src/routes/ContentStrategyPage.tsx
@@ -98,6 +98,10 @@ export default function ContentStrategyPage() {
     [cursor],
   );
 
+  // Compute today's ymd once per render rather than 42× inside the grid loop.
+  // Recomputed on every render so a session that crosses midnight catches up.
+  const todayYmd = useMemo(() => ymd(new Date()), []);
+
   const unscheduled = useMemo(() => posts.filter((p) => !p.scheduled_for), [posts]);
 
   function shiftMonth(delta: number) {
@@ -211,49 +215,45 @@ export default function ContentStrategyPage() {
             const inMonth = d.getMonth() === cursor.getMonth();
             const key = ymd(d);
             const dayPosts = byDate.get(key) ?? [];
-            const isToday = key === ymd(new Date());
+            const isToday = key === todayYmd;
             return (
-              <button
+              // The cell is a div (not a button) so the date-add button and
+              // the per-post edit buttons inside can each be independently
+              // focused — nesting <button> inside <button> is invalid HTML
+              // and breaks keyboard navigation.
+              <div
                 key={i}
-                type="button"
-                onClick={() => startNew(key)}
-                className={`flex min-h-24 flex-col gap-0.5 border-b border-r p-1 text-left text-[11px] hover:bg-slate-50 last:border-r-0 ${
+                className={`flex min-h-24 flex-col gap-0.5 border-b border-r p-1 text-left text-[11px] last:border-r-0 ${
                   inMonth ? "bg-white" : "bg-slate-50/50 text-slate-400"
                 }`}
               >
-                <span
-                  className={`text-[10px] ${
+                <button
+                  type="button"
+                  onClick={() => startNew(key)}
+                  aria-label={`Add post for ${key}`}
+                  className={`self-start rounded text-[10px] hover:underline ${
                     isToday ? "font-bold text-blue-700" : "text-slate-500"
                   }`}
                 >
                   {d.getDate()}
-                </span>
+                </button>
                 <div className="flex flex-col gap-0.5">
                   {dayPosts.slice(0, 3).map((p) => (
-                    <span
+                    <button
                       key={p.id}
-                      role="link"
-                      tabIndex={0}
-                      onClick={(e) => {
-                        e.stopPropagation();
+                      type="button"
+                      onClick={() => {
                         setEditing(p);
                         setShowForm(true);
                       }}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          e.stopPropagation();
-                          setEditing(p);
-                          setShowForm(true);
-                        }
-                      }}
-                      className={`truncate rounded px-1 py-0.5 text-[10px] hover:opacity-80 ${
+                      className={`truncate rounded px-1 py-0.5 text-left text-[10px] hover:opacity-80 ${
                         STATUS_COLORS[p.status as Status] ??
                         STATUS_COLORS.idea
                       }`}
                       title={p.title}
                     >
                       {p.title}
-                    </span>
+                    </button>
                   ))}
                   {dayPosts.length > 3 && (
                     <span className="text-[9px] text-slate-500">
@@ -261,7 +261,7 @@ export default function ContentStrategyPage() {
                     </span>
                   )}
                 </div>
-              </button>
+              </div>
             );
           })}
         </div>

--- a/apps/dataforseo-app/src/routes/ContentStrategyPage.tsx
+++ b/apps/dataforseo-app/src/routes/ContentStrategyPage.tsx
@@ -1,0 +1,493 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+
+import { formatError } from "../lib/errors";
+import { useProject } from "../lib/project-store";
+import {
+  tauriApi,
+  type PlannedPost,
+  type PlannedPostInput,
+} from "../lib/tauri";
+
+const STATUSES = ["idea", "drafting", "review", "published", "archived"] as const;
+type Status = (typeof STATUSES)[number];
+
+const STATUS_COLORS: Record<Status, string> = {
+  idea: "bg-slate-100 text-slate-700",
+  drafting: "bg-amber-100 text-amber-800",
+  review: "bg-violet-100 text-violet-800",
+  published: "bg-emerald-100 text-emerald-800",
+  archived: "bg-slate-200 text-slate-500",
+};
+
+function formatMonth(d: Date): string {
+  return d.toLocaleDateString(undefined, { year: "numeric", month: "long" });
+}
+
+function ymd(d: Date): string {
+  // Local-time YYYY-MM-DD; matches what an HTML date input emits, so stored
+  // values round-trip through the form without timezone drift.
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/// Build a 6×7 grid for the given month, padding with adjacent-month days
+/// so weekday columns line up. Mirrors the layout most CMS calendars use.
+function monthGrid(year: number, month: number): Date[] {
+  const first = new Date(year, month, 1);
+  // ISO weeks start Monday — shift Sunday (0) to slot 6 so Mon=0..Sun=6.
+  const startOffset = (first.getDay() + 6) % 7;
+  const start = new Date(year, month, 1 - startOffset);
+  const cells: Date[] = [];
+  for (let i = 0; i < 42; i++) {
+    cells.push(new Date(start.getFullYear(), start.getMonth(), start.getDate() + i));
+  }
+  return cells;
+}
+
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+export default function ContentStrategyPage() {
+  const { active: project } = useProject();
+
+  const [posts, setPosts] = useState<PlannedPost[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [editing, setEditing] = useState<PlannedPost | null>(null);
+  const [showForm, setShowForm] = useState(false);
+  const [cursor, setCursor] = useState(() => {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), 1);
+  });
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const list = await tauriApi.plannedPostsList({
+        projectId: project?.id ?? null,
+      });
+      setPosts(list);
+    } catch (e) {
+      toast.error(formatError(e, "Planned posts"));
+    } finally {
+      setLoading(false);
+    }
+  }, [project?.id]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Group posts by their scheduled_for date for fast calendar lookup.
+  const byDate = useMemo(() => {
+    const m = new Map<string, PlannedPost[]>();
+    for (const p of posts) {
+      if (!p.scheduled_for) continue;
+      const key = p.scheduled_for.slice(0, 10);
+      const arr = m.get(key) ?? [];
+      arr.push(p);
+      m.set(key, arr);
+    }
+    return m;
+  }, [posts]);
+
+  const grid = useMemo(
+    () => monthGrid(cursor.getFullYear(), cursor.getMonth()),
+    [cursor],
+  );
+
+  const unscheduled = useMemo(() => posts.filter((p) => !p.scheduled_for), [posts]);
+
+  function shiftMonth(delta: number) {
+    setCursor((c) => new Date(c.getFullYear(), c.getMonth() + delta, 1));
+  }
+
+  function startNew(scheduledFor?: string) {
+    setEditing({
+      id: 0,
+      project_id: project?.id ?? null,
+      title: "",
+      target_keyword: null,
+      status: "idea",
+      scheduled_for: scheduledFor ?? null,
+      notes: null,
+      created_at: null,
+      updated_at: null,
+    });
+    setShowForm(true);
+  }
+
+  async function save(input: PlannedPostInput) {
+    setBusy(true);
+    try {
+      if (editing && editing.id > 0) {
+        await tauriApi.plannedPostsUpdate({ id: editing.id, input });
+        toast.success("Post updated");
+      } else {
+        await tauriApi.plannedPostsCreate({ input });
+        toast.success("Post added");
+      }
+      setShowForm(false);
+      setEditing(null);
+      await refresh();
+    } catch (e) {
+      toast.error(formatError(e, "Save"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove(post: PlannedPost) {
+    if (!confirm(`Delete "${post.title}"?`)) return;
+    setBusy(true);
+    try {
+      await tauriApi.plannedPostsDelete({ id: post.id });
+      toast.success("Post deleted");
+      await refresh();
+    } catch (e) {
+      toast.error(formatError(e, "Delete"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="flex flex-col gap-6">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-xl font-semibold">Content Strategy</h2>
+          <p className="text-sm text-slate-600">
+            Editorial calendar — plan posts per project, track status, and stage
+            target keywords. Phase 2 will add topic clusters and the gap-to-brief
+            pipeline.
+          </p>
+          {project && (
+            <p className="mt-1 text-xs text-slate-500">
+              Project: <strong>{project.name}</strong> ({project.target})
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => startNew()}
+          className="rounded bg-slate-800 px-3 py-2 text-sm text-white hover:bg-slate-700"
+        >
+          + New post
+        </button>
+      </header>
+
+      {/* Calendar */}
+      <div className="rounded border bg-white">
+        <div className="flex items-center justify-between border-b px-3 py-2">
+          <button
+            type="button"
+            onClick={() => shiftMonth(-1)}
+            className="rounded px-2 py-1 text-sm hover:bg-slate-100"
+            aria-label="Previous month"
+          >
+            ◀
+          </button>
+          <h3 className="text-sm font-semibold">{formatMonth(cursor)}</h3>
+          <button
+            type="button"
+            onClick={() => shiftMonth(1)}
+            className="rounded px-2 py-1 text-sm hover:bg-slate-100"
+            aria-label="Next month"
+          >
+            ▶
+          </button>
+        </div>
+        <div className="grid grid-cols-7 border-b text-[11px] uppercase text-slate-500">
+          {WEEKDAYS.map((w) => (
+            <div key={w} className="border-r px-2 py-1 last:border-r-0">
+              {w}
+            </div>
+          ))}
+        </div>
+        <div className="grid grid-cols-7">
+          {grid.map((d, i) => {
+            const inMonth = d.getMonth() === cursor.getMonth();
+            const key = ymd(d);
+            const dayPosts = byDate.get(key) ?? [];
+            const isToday = key === ymd(new Date());
+            return (
+              <button
+                key={i}
+                type="button"
+                onClick={() => startNew(key)}
+                className={`flex min-h-24 flex-col gap-0.5 border-b border-r p-1 text-left text-[11px] hover:bg-slate-50 last:border-r-0 ${
+                  inMonth ? "bg-white" : "bg-slate-50/50 text-slate-400"
+                }`}
+              >
+                <span
+                  className={`text-[10px] ${
+                    isToday ? "font-bold text-blue-700" : "text-slate-500"
+                  }`}
+                >
+                  {d.getDate()}
+                </span>
+                <div className="flex flex-col gap-0.5">
+                  {dayPosts.slice(0, 3).map((p) => (
+                    <span
+                      key={p.id}
+                      role="link"
+                      tabIndex={0}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setEditing(p);
+                        setShowForm(true);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.stopPropagation();
+                          setEditing(p);
+                          setShowForm(true);
+                        }
+                      }}
+                      className={`truncate rounded px-1 py-0.5 text-[10px] hover:opacity-80 ${
+                        STATUS_COLORS[p.status as Status] ??
+                        STATUS_COLORS.idea
+                      }`}
+                      title={p.title}
+                    >
+                      {p.title}
+                    </span>
+                  ))}
+                  {dayPosts.length > 3 && (
+                    <span className="text-[9px] text-slate-500">
+                      +{dayPosts.length - 3} more
+                    </span>
+                  )}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Unscheduled bucket */}
+      <div className="rounded border bg-white">
+        <h3 className="border-b px-3 py-2 text-sm font-semibold">
+          Unscheduled ideas{" "}
+          <span className="font-normal text-slate-500">({unscheduled.length})</span>
+        </h3>
+        {loading ? (
+          <p className="px-3 py-4 text-sm text-slate-500">Loading…</p>
+        ) : unscheduled.length === 0 ? (
+          <p className="px-3 py-4 text-sm text-slate-500">
+            No unscheduled posts. Click a calendar cell or "+ New post" to add one.
+          </p>
+        ) : (
+          <ul className="divide-y">
+            {unscheduled.map((p) => (
+              <li
+                key={p.id}
+                className="flex flex-wrap items-center gap-2 px-3 py-2 text-sm hover:bg-slate-50"
+              >
+                <span
+                  className={`rounded px-1.5 py-0.5 text-[10px] ${
+                    STATUS_COLORS[p.status as Status] ?? STATUS_COLORS.idea
+                  }`}
+                >
+                  {p.status}
+                </span>
+                <span className="font-medium">{p.title}</span>
+                {p.target_keyword && (
+                  <span className="font-mono text-xs text-slate-500">
+                    → {p.target_keyword}
+                  </span>
+                )}
+                <div className="ml-auto flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditing(p);
+                      setShowForm(true);
+                    }}
+                    className="text-xs text-blue-600 hover:underline"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => remove(p)}
+                    className="text-xs text-red-600 hover:underline"
+                  >
+                    Delete
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Edit / Create modal */}
+      {showForm && editing && (
+        <PostForm
+          post={editing}
+          busy={busy}
+          onSave={save}
+          onDelete={
+            editing.id > 0
+              ? () => {
+                  void remove(editing).then(() => {
+                    setShowForm(false);
+                    setEditing(null);
+                  });
+                }
+              : undefined
+          }
+          onCancel={() => {
+            setShowForm(false);
+            setEditing(null);
+          }}
+        />
+      )}
+    </section>
+  );
+}
+
+function PostForm({
+  post,
+  busy,
+  onSave,
+  onDelete,
+  onCancel,
+}: {
+  post: PlannedPost;
+  busy: boolean;
+  onSave: (input: PlannedPostInput) => void | Promise<void>;
+  onDelete?: () => void;
+  onCancel: () => void;
+}) {
+  const [title, setTitle] = useState(post.title);
+  const [targetKeyword, setTargetKeyword] = useState(post.target_keyword ?? "");
+  const [status, setStatus] = useState<Status>((post.status as Status) ?? "idea");
+  const [scheduledFor, setScheduledFor] = useState(post.scheduled_for ?? "");
+  const [notes, setNotes] = useState(post.notes ?? "");
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) return;
+    void onSave({
+      project_id: post.project_id,
+      title: title.trim(),
+      target_keyword: targetKeyword.trim() || null,
+      status,
+      scheduled_for: scheduledFor || null,
+      notes: notes.trim() || null,
+    });
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4"
+      onClick={onCancel}
+    >
+      <form
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={submit}
+        className="flex w-full max-w-md flex-col gap-3 rounded border bg-white p-4 shadow-xl"
+      >
+        <h3 className="text-sm font-semibold">
+          {post.id > 0 ? "Edit post" : "New post"}
+        </h3>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-slate-700">Title</span>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            disabled={busy}
+            required
+            className="rounded border px-2 py-1 text-sm disabled:bg-slate-50"
+            placeholder="How to pick an SEO agency"
+            autoFocus
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-slate-700">Target keyword</span>
+          <input
+            type="text"
+            value={targetKeyword}
+            onChange={(e) => setTargetKeyword(e.target.value)}
+            disabled={busy}
+            className="rounded border px-2 py-1 font-mono text-sm disabled:bg-slate-50"
+            placeholder="seo agency"
+          />
+        </label>
+        <div className="grid grid-cols-2 gap-2">
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-slate-700">Status</span>
+            <select
+              value={status}
+              onChange={(e) => setStatus(e.target.value as Status)}
+              disabled={busy}
+              className="rounded border px-2 py-1 text-sm disabled:bg-slate-50"
+            >
+              {STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-slate-700">Scheduled</span>
+            <input
+              type="date"
+              value={scheduledFor}
+              onChange={(e) => setScheduledFor(e.target.value)}
+              disabled={busy}
+              className="rounded border px-2 py-1 text-sm disabled:bg-slate-50"
+            />
+          </label>
+        </div>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="font-medium text-slate-700">Notes</span>
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            disabled={busy}
+            className="h-20 rounded border px-2 py-1 text-sm disabled:bg-slate-50"
+            placeholder="Outline, references, internal links to add…"
+          />
+        </label>
+        <div className="flex justify-between gap-2 pt-2">
+          {onDelete ? (
+            <button
+              type="button"
+              onClick={onDelete}
+              disabled={busy}
+              className="rounded border border-red-200 px-3 py-1.5 text-sm text-red-700 hover:bg-red-50 disabled:opacity-60"
+            >
+              Delete
+            </button>
+          ) : (
+            <span />
+          )}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              disabled={busy}
+              className="rounded border px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={busy || !title.trim()}
+              className="rounded bg-slate-800 px-3 py-1.5 text-sm text-white hover:bg-slate-700 disabled:opacity-60"
+            >
+              {busy ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
Phase 1 of 3 on #68 (content-strategy epic).

## Summary

Adds an **editorial calendar** for planning posts per project — title, target keyword, status (`idea` → `drafting` → `review` → `published` → `archived`), scheduled-for date, and notes. Phases 2 and 3 follow in separate PRs.

## Changes

### Backend
| File | What |
|---|---|
| `migrations/v0010_content_strategy.sql` | New `planned_posts` table with `project_id` FK + indexes on `project_id` / `scheduled_for` / `status` |
| `store/content_strategy.rs` | CRUD module — `create()` uses `INSERT...RETURNING id` for atomic ID retrieval, `list()` is project-scoped |
| `commands/content_strategy.rs` | Four Tauri commands: `planned_posts_list` / `_create` / `_update` / `_delete` + `PlannedPostInput` type |
| Registration in `store/mod.rs`, `commands/mod.rs`, `store/schema.rs`, `lib.rs` | Module + migration + invoke handlers |

### Frontend
| File | What |
|---|---|
| `routes/ContentStrategyPage.tsx` | New — month-grid calendar (Mon-Sun columns, click empty cell to add, click chip to edit), status-coloured chips, "Unscheduled ideas" bucket for date-less posts, modal `PostForm` for create/edit/delete |
| `lib/tauri.ts` | `PlannedPost` + `PlannedPostInput` interfaces + four `tauriApi.plannedPosts*` entries |
| `App.tsx` | New `/content-strategy` route + nav entry between Keyword Clustering and Topic Research |

## What's deferred to phases 2 + 3

- **Phase 2** — topic-cluster visualization + content-gap keyword table (using existing `domain_intersection` + `serp_organic_live`) with `ExportMenu`
- **Phase 3** — LLM brief generator using existing chat infra (Anthropic / OpenAI), Markdown export to Documents

## Test plan

- [x] `tsc --noEmit` passes ✅
- [x] `vitest run` — 107 tests pass ✅
- [ ] Manual: create a post, schedule it, see it appear on the calendar
- [ ] Manual: click the chip in a cell to edit; click empty cell to add for that date
- [ ] Manual: switch projects → calendar refreshes with posts scoped to the new project
- [ ] Manual: leave `scheduled_for` empty → post lands in the Unscheduled bucket

https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR

---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_