### PR TITLE
feat(content-strategy): LLM brief generator (phase 3, closes #68)

### DIFF
--- a/apps/dataforseo-app/src-tauri/migrations/v0012_content_brief.sql
+++ b/apps/dataforseo-app/src-tauri/migrations/v0012_content_brief.sql
@@ -1,0 +1,8 @@
+-- Phase 3 of content-strategy (issue #68): LLM-generated content briefs.
+-- Each planned post can have one current brief (Markdown) plus the
+-- model + timestamp so the UI can show staleness and the user can
+-- regenerate when the topic context changes.
+
+ALTER TABLE planned_posts ADD COLUMN IF NOT EXISTS brief_md           VARCHAR;
+ALTER TABLE planned_posts ADD COLUMN IF NOT EXISTS brief_model        VARCHAR;
+ALTER TABLE planned_posts ADD COLUMN IF NOT EXISTS brief_generated_at TIMESTAMP;

--- a/apps/dataforseo-app/src-tauri/src/ai/prompts.rs
+++ b/apps/dataforseo-app/src-tauri/src/ai/prompts.rs
@@ -90,12 +90,55 @@ then a final line `*N chars*` with the character count. The frontend \
 renders the assistant reply as Markdown directly — no JSON wrapping.",
 };
 
+pub const CONTENT_BRIEF: PromptTemplate = PromptTemplate {
+    id: "content_brief",
+    label: "Content brief",
+    description: "Generate an SEO content brief for a planned post.",
+    system: "\
+You are an SEO content strategist. The user will give you a planned blog \
+post (title + target keyword + optional cluster context + notes). Produce \
+a Markdown content brief with these sections, in this order:\n\
+\n\
+## Search intent\n\
+One sentence on the dominant intent (informational | commercial | \
+transactional | navigational) and what the searcher is trying to do.\n\
+\n\
+## Target audience\n\
+2-3 bullets describing who the reader is and what they already know.\n\
+\n\
+## Recommended outline\n\
+A nested H2/H3 outline (use `##` and `###` Markdown headings, not bullets) \
+covering the topic comprehensively. 5-9 H2 sections, each with 2-4 H3 \
+subsections. Cover the obvious angles plus 1-2 less-obvious ones a senior \
+strategist would flag.\n\
+\n\
+## Key points to cover\n\
+6-10 bullets — concrete claims, data points, or examples the post must \
+include to be authoritative.\n\
+\n\
+## FAQs\n\
+4-6 question/answer pairs aligned to People-Also-Ask style queries.\n\
+\n\
+## Internal linking ideas\n\
+3-5 bullets — suggested anchor text + a short note on the kind of \
+existing post each one should link to (you don't know the user's site, \
+so describe the post conceptually).\n\
+\n\
+## Meta\n\
+- **Title tag** (max 60 chars)\n\
+- **Meta description** (max 155 chars)\n\
+- **Target word count** (a single integer, based on intent and depth)\n\
+\n\
+Reply with ONLY the Markdown brief — no preamble, no closing remarks.",
+};
+
 pub const PROMPT_TEMPLATES: &[PromptTemplate] = &[
     CLUSTER_KEYWORDS,
     BLOG_IDEAS,
     KEYWORD_INTENT,
     TITLE_SUGGESTIONS,
     SOCIAL_DRAFTS,
+    CONTENT_BRIEF,
 ];
 
 pub fn find_template(id: &str) -> Option<&'static PromptTemplate> {

--- a/apps/dataforseo-app/src-tauri/src/commands/content_strategy.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/content_strategy.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use tauri::State;
 use ts_rs::TS;
 
+use crate::ai::prompts::CONTENT_BRIEF;
+use crate::ai::{ChatMessage, Role};
 use crate::errors::{AppError, Result};
 use crate::state::AppState;
 use crate::store;
@@ -176,4 +178,99 @@ pub async fn topic_clusters_delete(state: State<'_, AppState>, id: i64) -> Resul
     })
     .await
     .map_err(|e| AppError::Internal(e.to_string()))?
+}
+
+// ---------- content brief generator (phase 3) ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export, export_to = "../src/lib/types/")]
+pub struct ContentBrief {
+    pub post_id: i64,
+    pub brief_md: String,
+    pub model: String,
+    /// Output-side cost from the latest generation. The frontend can
+    /// surface this so the user knows what the call cost.
+    pub cost_usd: f64,
+}
+
+/// Generate (and persist) an SEO content brief for a planned post using
+/// the active AI provider. Pulls the post + its cluster (if any) for
+/// context, hands them to the LLM, stores the result on the row.
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn content_brief_generate(
+    state: State<'_, AppState>,
+    post_id: i64,
+) -> Result<ContentBrief> {
+    let client = state
+        .ai
+        .get()
+        .await
+        .ok_or_else(|| AppError::Auth("no AI provider configured".into()))?;
+
+    // Pull post + optional cluster in one DB hit so the caller sees a
+    // consistent snapshot even if another tab edits the row mid-flight.
+    let store = state.store.clone();
+    let (post, cluster) = tokio::task::spawn_blocking(move || -> Result<_> {
+        store.with_conn(|c| {
+            let post = store::content_strategy::get(c, post_id)?
+                .ok_or_else(|| AppError::Validation(format!("planned post {post_id} not found")))?;
+            let cluster = match post.cluster_id {
+                Some(cid) => store::content_strategy::cluster_get(c, cid)?,
+                None => None,
+            };
+            Ok((post, cluster))
+        })
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))??;
+
+    // Build the user-side context message. Keep it terse — the brief
+    // template does the heavy lifting in the system prompt.
+    let mut user_msg = String::new();
+    user_msg.push_str(&format!("Title: {}\n", post.title));
+    if let Some(kw) = &post.target_keyword {
+        user_msg.push_str(&format!("Target keyword: {kw}\n"));
+    }
+    if let Some(c) = &cluster {
+        user_msg.push_str(&format!("Cluster: {}", c.name));
+        if let Some(p) = &c.pillar_keyword {
+            user_msg.push_str(&format!(" (pillar: {p})"));
+        }
+        user_msg.push('\n');
+        if let Some(d) = &c.description {
+            user_msg.push_str(&format!("Cluster context: {d}\n"));
+        }
+    }
+    if let Some(notes) = &post.notes {
+        if !notes.trim().is_empty() {
+            user_msg.push_str(&format!("\nUser notes:\n{notes}\n"));
+        }
+    }
+
+    let messages = vec![ChatMessage {
+        role: Role::User,
+        content: user_msg,
+    }];
+
+    let response = client
+        .chat_with_system(Some(CONTENT_BRIEF.system), &messages)
+        .await?;
+
+    // Persist the brief so the UI reload picks it up immediately.
+    let store = state.store.clone();
+    let brief_md = response.content.clone();
+    let model = response.model.clone();
+    tokio::task::spawn_blocking(move || -> Result<()> {
+        store.with_conn(|c| store::content_strategy::set_brief(c, post_id, &brief_md, &model))
+    })
+    .await
+    .map_err(|e| AppError::Internal(e.to_string()))??;
+
+    Ok(ContentBrief {
+        post_id,
+        brief_md: response.content,
+        model: response.model,
+        cost_usd: response.usage.cost_usd,
+    })
 }

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -216,6 +216,7 @@ pub fn run() {
             commands::content_strategy::topic_clusters_create,
             commands::content_strategy::topic_clusters_update,
             commands::content_strategy::topic_clusters_delete,
+            commands::content_strategy::content_brief_generate,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/dataforseo-app/src-tauri/src/store/content_strategy.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/content_strategy.rs
@@ -21,6 +21,11 @@ pub struct PlannedPost {
     /// ISO date (YYYY-MM-DD) the post is scheduled to be published.
     pub scheduled_for: Option<String>,
     pub notes: Option<String>,
+    /// Latest LLM-generated content brief (Markdown). Generated on demand
+    /// via the `content_brief_generate` command.
+    pub brief_md: Option<String>,
+    pub brief_model: Option<String>,
+    pub brief_generated_at: Option<String>,
     pub created_at: Option<String>,
     pub updated_at: Option<String>,
 }
@@ -109,6 +114,88 @@ pub fn delete(conn: &mut Connection, id: i64) -> Result<()> {
     Ok(())
 }
 
+/// Persist the latest LLM-generated brief on the post. Stamps the model
+/// and timestamp so the UI can show staleness.
+pub fn set_brief(
+    conn: &mut Connection,
+    id: i64,
+    brief_md: &str,
+    model: &str,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE planned_posts
+            SET brief_md = $2,
+                brief_model = $3,
+                brief_generated_at = CURRENT_TIMESTAMP,
+                updated_at = CURRENT_TIMESTAMP
+          WHERE id = $1",
+        params![id, brief_md, model],
+    )?;
+    Ok(())
+}
+
+/// Read a post by id. Used by the brief generator to assemble context
+/// (title, target keyword, cluster_id, notes) before calling the LLM.
+pub fn get(conn: &mut Connection, id: i64) -> Result<Option<PlannedPost>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, project_id, cluster_id, title, target_keyword, status,
+                CAST(scheduled_for AS VARCHAR)        AS scheduled_for_s,
+                notes,
+                brief_md,
+                brief_model,
+                CAST(brief_generated_at AS VARCHAR)   AS brief_generated_at_s,
+                CAST(created_at AS VARCHAR)           AS created_at_s,
+                CAST(updated_at AS VARCHAR)           AS updated_at_s
+           FROM planned_posts
+          WHERE id = $1",
+    )?;
+    let mut rows = stmt.query(params![id])?;
+    if let Some(row) = rows.next()? {
+        Ok(Some(PlannedPost {
+            id: row.get("id")?,
+            project_id: row.get("project_id")?,
+            cluster_id: row.get("cluster_id")?,
+            title: row.get("title")?,
+            target_keyword: row.get("target_keyword")?,
+            status: row.get("status")?,
+            scheduled_for: row.get("scheduled_for_s")?,
+            notes: row.get("notes")?,
+            brief_md: row.get("brief_md")?,
+            brief_model: row.get("brief_model")?,
+            brief_generated_at: row.get("brief_generated_at_s")?,
+            created_at: row.get("created_at_s")?,
+            updated_at: row.get("updated_at_s")?,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn cluster_get(conn: &mut Connection, id: i64) -> Result<Option<TopicCluster>> {
+    let mut stmt = conn.prepare(
+        "SELECT id, project_id, name, pillar_keyword, description, color,
+                CAST(created_at AS VARCHAR) AS created_at_s,
+                CAST(updated_at AS VARCHAR) AS updated_at_s
+           FROM topic_clusters
+          WHERE id = $1",
+    )?;
+    let mut rows = stmt.query(params![id])?;
+    if let Some(row) = rows.next()? {
+        Ok(Some(TopicCluster {
+            id: row.get("id")?,
+            project_id: row.get("project_id")?,
+            name: row.get("name")?,
+            pillar_keyword: row.get("pillar_keyword")?,
+            description: row.get("description")?,
+            color: row.get("color")?,
+            created_at: row.get("created_at_s")?,
+            updated_at: row.get("updated_at_s")?,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
 /// List planned posts for a project (or all if `project_id` is None).
 /// Newest scheduled date first, then by created_at.
 pub fn list(conn: &mut Connection, project_id: Option<i64>) -> Result<Vec<PlannedPost>> {
@@ -118,19 +205,25 @@ pub fn list(conn: &mut Connection, project_id: Option<i64>) -> Result<Vec<Planne
     // SELECT-list reorders.
     let sql = if project_id.is_some() {
         "SELECT id, project_id, cluster_id, title, target_keyword, status,
-                CAST(scheduled_for AS VARCHAR) AS scheduled_for_s,
+                CAST(scheduled_for AS VARCHAR)      AS scheduled_for_s,
                 notes,
-                CAST(created_at AS VARCHAR)    AS created_at_s,
-                CAST(updated_at AS VARCHAR)    AS updated_at_s
+                brief_md,
+                brief_model,
+                CAST(brief_generated_at AS VARCHAR) AS brief_generated_at_s,
+                CAST(created_at AS VARCHAR)         AS created_at_s,
+                CAST(updated_at AS VARCHAR)         AS updated_at_s
            FROM planned_posts
           WHERE project_id = $1
           ORDER BY scheduled_for DESC NULLS LAST, created_at DESC"
     } else {
         "SELECT id, project_id, cluster_id, title, target_keyword, status,
-                CAST(scheduled_for AS VARCHAR) AS scheduled_for_s,
+                CAST(scheduled_for AS VARCHAR)      AS scheduled_for_s,
                 notes,
-                CAST(created_at AS VARCHAR)    AS created_at_s,
-                CAST(updated_at AS VARCHAR)    AS updated_at_s
+                brief_md,
+                brief_model,
+                CAST(brief_generated_at AS VARCHAR) AS brief_generated_at_s,
+                CAST(created_at AS VARCHAR)         AS created_at_s,
+                CAST(updated_at AS VARCHAR)         AS updated_at_s
            FROM planned_posts
           ORDER BY scheduled_for DESC NULLS LAST, created_at DESC"
     };
@@ -153,6 +246,9 @@ pub fn list(conn: &mut Connection, project_id: Option<i64>) -> Result<Vec<Planne
             status: row.get("status")?,
             scheduled_for: row.get("scheduled_for_s")?,
             notes: row.get("notes")?,
+            brief_md: row.get("brief_md")?,
+            brief_model: row.get("brief_model")?,
+            brief_generated_at: row.get("brief_generated_at_s")?,
             created_at: row.get("created_at_s")?,
             updated_at: row.get("updated_at_s")?,
         });

--- a/apps/dataforseo-app/src-tauri/src/store/schema.rs
+++ b/apps/dataforseo-app/src-tauri/src/store/schema.rs
@@ -16,6 +16,7 @@ const MIGRATIONS: &[(u32, &str)] = &[
     (9, include_str!("../../migrations/v0009_semrush_import.sql")),
     (10, include_str!("../../migrations/v0010_content_strategy.sql")),
     (11, include_str!("../../migrations/v0011_topic_clusters.sql")),
+    (12, include_str!("../../migrations/v0012_content_brief.sql")),
 ];
 
 pub fn ensure_current(conn: &mut Connection) -> Result<()> {

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -426,6 +426,9 @@ export const tauriApi = {
 
   topicClustersDelete: (args: { id: number }) =>
     invoke<void>("topic_clusters_delete", args),
+
+  contentBriefGenerate: (args: { postId: number }) =>
+    invoke<ContentBrief>("content_brief_generate", args),
 };
 
 export interface AiProviderStatus {
@@ -1210,8 +1213,18 @@ export interface PlannedPost {
   /** ISO YYYY-MM-DD */
   scheduled_for: string | null;
   notes: string | null;
+  brief_md: string | null;
+  brief_model: string | null;
+  brief_generated_at: string | null;
   created_at: string | null;
   updated_at: string | null;
+}
+
+export interface ContentBrief {
+  post_id: number;
+  brief_md: string;
+  model: string;
+  cost_usd: number;
 }
 
 export interface PlannedPostInput {

--- a/apps/dataforseo-app/src/routes/content-strategy/BriefView.tsx
+++ b/apps/dataforseo-app/src/routes/content-strategy/BriefView.tsx
@@ -1,0 +1,174 @@
+import { useState } from "react";
+import toast from "react-hot-toast";
+
+import MarkdownView from "../../components/MarkdownView";
+import { formatError } from "../../lib/errors";
+import { formatUsd } from "../../lib/format";
+import {
+  tauriApi,
+  type ContentBrief,
+  type PlannedPost,
+} from "../../lib/tauri";
+
+interface Props {
+  post: PlannedPost;
+  onClose: () => void;
+  /// Called after a successful (re)generation so the parent can refresh
+  /// its post list and pick up the persisted brief.
+  onGenerated: () => void | Promise<void>;
+}
+
+function formatTimestamp(ts: string | null | undefined): string {
+  if (!ts) return "—";
+  const d = new Date(ts.replace(" ", "T"));
+  if (Number.isNaN(d.getTime())) return ts;
+  return d.toLocaleString();
+}
+
+export default function BriefView({ post, onClose, onGenerated }: Props) {
+  const [busy, setBusy] = useState(false);
+  // Local state holds the just-generated brief so we render fresh content
+  // before the parent's refresh round-trip lands.
+  const [latest, setLatest] = useState<ContentBrief | null>(null);
+
+  const briefMd = latest?.brief_md ?? post.brief_md ?? "";
+  const model = latest?.model ?? post.brief_model ?? null;
+  const generatedAt = latest
+    ? new Date().toISOString()
+    : post.brief_generated_at;
+
+  async function generate() {
+    setBusy(true);
+    try {
+      const result = await tauriApi.contentBriefGenerate({ postId: post.id });
+      setLatest(result);
+      toast.success(
+        `Brief generated (${result.model}, ${formatUsd(result.cost_usd)})`,
+      );
+      await onGenerated();
+    } catch (e) {
+      toast.error(formatError(e, "Generate brief"));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function copy() {
+    if (!briefMd) return;
+    try {
+      await navigator.clipboard.writeText(briefMd);
+      toast.success("Brief copied as Markdown");
+    } catch (e) {
+      toast.error(formatError(e, "Copy"));
+    }
+  }
+
+  function downloadMd() {
+    if (!briefMd) return;
+    const safeTitle = post.title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 60);
+    const blob = new Blob([briefMd], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${safeTitle || "brief"}-brief.md`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  const hasBrief = briefMd.length > 0;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="flex max-h-[90vh] w-full max-w-3xl flex-col rounded border bg-white shadow-xl"
+      >
+        <header className="flex items-start justify-between gap-4 border-b px-4 py-3">
+          <div>
+            <h3 className="text-base font-semibold">Content brief</h3>
+            <p className="text-xs text-slate-500">{post.title}</p>
+            {hasBrief && (
+              <p className="mt-1 text-[11px] text-slate-500">
+                {model && <span className="font-mono">{model}</span>} ·
+                generated {formatTimestamp(generatedAt)}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="rounded px-2 py-1 text-slate-500 hover:bg-slate-100"
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto px-4 py-3">
+          {busy ? (
+            <p className="py-8 text-center text-sm text-slate-500">
+              Generating brief… this usually takes 10-30 seconds.
+            </p>
+          ) : hasBrief ? (
+            <MarkdownView content={briefMd} />
+          ) : (
+            <div className="py-8 text-center text-sm text-slate-500">
+              No brief yet. Click <strong>Generate</strong> to draft one with
+              the active AI provider. Requires an API key configured in
+              Settings.
+            </div>
+          )}
+        </div>
+
+        <footer className="flex flex-wrap items-center justify-between gap-2 border-t px-4 py-3">
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={generate}
+              disabled={busy}
+              className="rounded bg-slate-800 px-3 py-1.5 text-sm text-white hover:bg-slate-700 disabled:opacity-60"
+            >
+              {busy ? "Generating…" : hasBrief ? "Regenerate" : "Generate"}
+            </button>
+            {hasBrief && (
+              <>
+                <button
+                  type="button"
+                  onClick={copy}
+                  disabled={busy}
+                  className="rounded border px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 disabled:opacity-60"
+                >
+                  Copy
+                </button>
+                <button
+                  type="button"
+                  onClick={downloadMd}
+                  disabled={busy}
+                  className="rounded border px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100 disabled:opacity-60"
+                >
+                  Download .md
+                </button>
+              </>
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-100"
+          >
+            Close
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/apps/dataforseo-app/src/routes/content-strategy/CalendarTab.tsx
+++ b/apps/dataforseo-app/src/routes/content-strategy/CalendarTab.tsx
@@ -44,6 +44,7 @@ interface Props {
     input: PlannedPostInput,
   ) => void | Promise<void>;
   onDelete: (post: PlannedPost) => void | Promise<void>;
+  onOpenBrief: (post: PlannedPost) => void;
 }
 
 export default function CalendarTab({
@@ -54,6 +55,7 @@ export default function CalendarTab({
   defaultProjectId,
   onSave,
   onDelete,
+  onOpenBrief,
 }: Props) {
   const [editing, setEditing] = useState<PlannedPost | null>(null);
   const [showForm, setShowForm] = useState(false);
@@ -101,6 +103,9 @@ export default function CalendarTab({
       status: "idea",
       scheduled_for: scheduledFor ?? null,
       notes: null,
+      brief_md: null,
+      brief_model: null,
+      brief_generated_at: null,
       created_at: null,
       updated_at: null,
     });
@@ -284,6 +289,18 @@ export default function CalendarTab({
             setShowForm(false);
             setEditing(null);
           }}
+          onOpenBrief={
+            editing.id > 0
+              ? () => {
+                  // Hand off to the host's BriefView. Close the form so the
+                  // user isn't stacking modals.
+                  const target = editing;
+                  setShowForm(false);
+                  setEditing(null);
+                  onOpenBrief(target);
+                }
+              : undefined
+          }
         />
       )}
     </div>

--- a/apps/dataforseo-app/src/routes/content-strategy/ContentStrategyPage.tsx
+++ b/apps/dataforseo-app/src/routes/content-strategy/ContentStrategyPage.tsx
@@ -11,6 +11,7 @@ import {
   type TopicClusterInput,
 } from "../../lib/tauri";
 
+import BriefView from "./BriefView";
 import CalendarTab from "./CalendarTab";
 import ClustersTab from "./ClustersTab";
 import GapTab from "./GapTab";
@@ -34,6 +35,7 @@ export default function ContentStrategyPage() {
   const [loadingClusters, setLoadingClusters] = useState(false);
   const [busy, setBusy] = useState(false);
   const [editingPost, setEditingPost] = useState<PlannedPost | null>(null);
+  const [briefingPost, setBriefingPost] = useState<PlannedPost | null>(null);
 
   const refreshPosts = useCallback(async () => {
     setLoadingPosts(true);
@@ -182,6 +184,7 @@ export default function ContentStrategyPage() {
           defaultProjectId={project?.id ?? null}
           onSave={savePost}
           onDelete={deletePost}
+          onOpenBrief={(p) => setBriefingPost(p)}
         />
       )}
 
@@ -228,6 +231,25 @@ export default function ContentStrategyPage() {
               : undefined
           }
           onCancel={() => setEditingPost(null)}
+          onOpenBrief={
+            editingPost.id > 0
+              ? () => {
+                  const target = editingPost;
+                  setEditingPost(null);
+                  setBriefingPost(target);
+                }
+              : undefined
+          }
+        />
+      )}
+
+      {briefingPost && (
+        <BriefView
+          // Re-resolve from the latest list so a regenerate completion
+          // re-renders with the persisted timestamp + model.
+          post={posts.find((p) => p.id === briefingPost.id) ?? briefingPost}
+          onClose={() => setBriefingPost(null)}
+          onGenerated={refreshPosts}
         />
       )}
     </section>

--- a/apps/dataforseo-app/src/routes/content-strategy/PostForm.tsx
+++ b/apps/dataforseo-app/src/routes/content-strategy/PostForm.tsx
@@ -30,6 +30,9 @@ interface Props {
   onSave: (input: PlannedPostInput) => void | Promise<void>;
   onDelete?: () => void;
   onCancel: () => void;
+  /// Opens the LLM brief modal. Only meaningful for existing posts
+  /// (id > 0); the host hides the button on the create-new flow.
+  onOpenBrief?: () => void;
 }
 
 export default function PostForm({
@@ -39,6 +42,7 @@ export default function PostForm({
   onSave,
   onDelete,
   onCancel,
+  onOpenBrief,
 }: Props) {
   const [title, setTitle] = useState(post.title);
   const [targetKeyword, setTargetKeyword] = useState(post.target_keyword ?? "");
@@ -170,6 +174,21 @@ export default function PostForm({
             <span />
           )}
           <div className="flex gap-2">
+            {post.id > 0 && onOpenBrief && (
+              <button
+                type="button"
+                onClick={onOpenBrief}
+                disabled={busy}
+                className="rounded border border-violet-200 px-3 py-1.5 text-sm text-violet-700 hover:bg-violet-50 disabled:opacity-60"
+                title={
+                  post.brief_md
+                    ? "View / regenerate brief"
+                    : "Generate an AI content brief"
+                }
+              >
+                {post.brief_md ? "Brief ✓" : "Brief"}
+              </button>
+            )}
             <button
               type="button"
               onClick={onCancel}


### PR DESCRIPTION
Phase 3 of 3 — closes #68. Phase 1 (#74) shipped the calendar; phase 2 (#75) shipped clusters + content gap. This PR completes the workflow with an on-demand LLM content-brief generator.

## Summary

A new **Brief** button on every existing planned post opens a modal that:
- Calls the active AI provider (Anthropic / OpenAI, configured in Settings) with the post's title + target keyword + cluster context + notes
- Renders the resulting Markdown brief with full GFM + sanitization via the existing `MarkdownView`
- Persists `brief_md` + `brief_model` + `brief_generated_at` on the row so the brief survives app restarts and the UI can show staleness
- Lets the user **Copy** to clipboard or **Download .md** for handoff to a writer

The brief itself follows a senior-strategist structure: Search Intent → Target Audience → H2/H3 Outline → Key Points → FAQs → Internal Linking → Meta (title tag / meta description / target word count).

## Changes

### Backend
| File | What |
|---|---|
| `migrations/v0012_content_brief.sql` | Adds `brief_md` / `brief_model` / `brief_generated_at` to `planned_posts` (additive, nullable) |
| `store/content_strategy.rs` | `PlannedPost` gains brief fields; new `set_brief()` / `get()` / `cluster_get()` helpers. `list()` projects the new columns |
| `ai/prompts.rs` | New `CONTENT_BRIEF` template (added to `PROMPT_TEMPLATES`) |
| `commands/content_strategy.rs` | `content_brief_generate(post_id)` — pulls post + cluster in one DB hit, builds a terse user message, hands off to the active `AiClient` via `chat_with_system`, persists the result. Returns `{ post_id, brief_md, model, cost_usd }` |
| `lib.rs` | Registered the new invoke handler |

### Frontend
| File | What |
|---|---|
| `routes/content-strategy/BriefView.tsx` | New modal — Generate / Regenerate / Copy / Download .md. Renders via `MarkdownView`. Shows model + timestamp |
| `routes/content-strategy/PostForm.tsx` | Gains a `Brief` / `Brief ✓` button (only on existing posts) that hands off to the host's BriefView |
| `routes/content-strategy/ContentStrategyPage.tsx` | Owns `briefingPost` state; resolves the briefed post against the latest list so a regenerate re-renders with the persisted timestamp |
| `routes/content-strategy/CalendarTab.tsx` | Threads `onOpenBrief` to its inner PostForm |
| `lib/tauri.ts` | `ContentBrief` interface + brief fields on `PlannedPost`, `contentBriefGenerate` API entry |

## Cost

Each brief is one `chat_with_system` call against the active provider — typically 200-500 input tokens + 1500-3000 output tokens. Anthropic Sonnet ≈ $0.02-0.05; OpenAI gpt-4o-mini ≈ $0.001. Cost is reported in the toast and on the brief response.

## Test plan

- [x] `tsc --noEmit` passes ✅
- [x] `vitest run` — 107 tests pass ✅
- [ ] Manual: configure an AI provider in Settings, open an existing post, click **Brief**, click **Generate** → verify the Markdown renders cleanly
- [ ] Manual: assign the post to a cluster with a pillar keyword + description → regenerate → verify the brief picks up the cluster context
- [ ] Manual: **Copy** → paste into a new doc, **Download .md** → file downloads with a slugified filename
- [ ] Manual: close + re-open the modal — the persisted brief shows immediately (DB round-trip)
- [ ] Manual: with no provider configured, click Generate → toast shows the auth error (no crash)

https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR

---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_