### PR TITLE
feat(dataforseo-app): Clickstream Bulk Search Volume

### DIFF
--- a/apps/dataforseo-app/docs/DATAFORSEO_API_ENDPOINTS.md
+++ b/apps/dataforseo-app/docs/DATAFORSEO_API_ENDPOINTS.md
@@ -40,7 +40,7 @@ Google Ads search-volume data and clickstream-derived stats.
 | Bing · Keyword Performance | `/v3/keywords_data/bing/keyword_performance/live` | 0.05 | — | 🟦 plan |
 | Bing · Search Volume | `/v3/keywords_data/bing/search_volume/live` | 0.05 | — | 🟦 plan |
 | Bing · Locations | `/v3/keywords_data/bing/locations` | free | — | n/a |
-| Clickstream · Bulk Search Volume | `/v3/keywords_data/clickstream_data/bulk_search_volume/live` | 0.0006 / kw | — | 🟡 next |
+| Clickstream · Bulk Search Volume | `/v3/keywords_data/clickstream_data/bulk_search_volume/live` | 0.0006 / kw | — | ✅ done |
 | Clickstream · Dataforseo Search Volume | `/v3/keywords_data/dataforseo_trends/explore/live` | 0.05 | — | 🟦 plan |
 
 ## DataForSEO Labs API

--- a/apps/dataforseo-app/src-tauri/src/api/keywords_data.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/keywords_data.rs
@@ -172,6 +172,54 @@ impl ApiClient {
         Ok(SearchVolumeResponse { items, cost })
     }
 
+    /// Clickstream Bulk Search Volume.
+    ///
+    /// 0.0006 USD per keyword (one third the per-kw cost of Google Ads
+    /// Search Volume, six times the price of Labs Bulk Search Volume).
+    /// Source is DataForSEO's clickstream panel rather than Google Ads
+    /// estimates — typically more accurate on long-tail terms but won't
+    /// match Google Ads numbers head-to-head. The response is intentionally
+    /// minimal: `keyword`, `search_volume`, and `monthly_searches`
+    /// (no competition / CPC, since clickstream isn't an ad-auction source).
+    pub async fn clickstream_bulk_search_volume_live(
+        &self,
+        keywords: &[String],
+        location_code: u32,
+        language_code: &str,
+    ) -> Result<SearchVolumeResponse> {
+        if keywords.is_empty() {
+            return Ok(SearchVolumeResponse { items: Vec::new(), cost: 0.0 });
+        }
+        if keywords.len() > 1000 {
+            return Err(AppError::Validation(
+                "clickstream_bulk_search_volume accepts at most 1000 keywords per request".into(),
+            ));
+        }
+        let body = serde_json::json!([{
+            "keywords": keywords,
+            "location_code": location_code,
+            "language_code": language_code,
+        }]);
+        let raw = self
+            .post_json(
+                Family::KeywordsData,
+                "/v3/keywords_data/clickstream_data/bulk_search_volume/live",
+                &body,
+            )
+            .await?;
+        let cost = ensure_api_success(&raw)?;
+        let items = raw
+            .pointer("/tasks/0/result")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|i| serde_json::from_value::<SearchVolumeItem>(i.clone()).ok())
+                    .collect()
+            })
+            .unwrap_or_default();
+        Ok(SearchVolumeResponse { items, cost })
+    }
+
     /// Keyword expansion from a seed keyword set.
     pub async fn google_ads_keywords_for_keywords_live(
         &self,

--- a/apps/dataforseo-app/src-tauri/src/api/keywords_data.rs
+++ b/apps/dataforseo-app/src-tauri/src/api/keywords_data.rs
@@ -211,12 +211,14 @@ impl ApiClient {
         let items = raw
             .pointer("/tasks/0/result")
             .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|i| serde_json::from_value::<SearchVolumeItem>(i.clone()).ok())
-                    .collect()
-            })
-            .unwrap_or_default();
+            .ok_or_else(|| {
+                AppError::Parse(
+                    "clickstream_bulk_search_volume response missing tasks[0].result".into(),
+                )
+            })?
+            .iter()
+            .filter_map(|i| serde_json::from_value::<SearchVolumeItem>(i.clone()).ok())
+            .collect();
         Ok(SearchVolumeResponse { items, cost })
     }
 

--- a/apps/dataforseo-app/src-tauri/src/commands/keywords.rs
+++ b/apps/dataforseo-app/src-tauri/src/commands/keywords.rs
@@ -1037,6 +1037,94 @@ pub async fn labs_bulk_search_volume(
     Ok(view)
 }
 
+// ---------- Clickstream Bulk Search Volume ----------
+//
+// Same input/output shape as `labs_bulk_search_volume` so the Bulk Volume
+// tab can switch between Labs (Google-Ads-derived, 0.0001/kw) and
+// Clickstream (panel-based, 0.0006/kw) without forking the UI. Clickstream
+// only returns keyword + volume, so competition/competition_level/cpc on
+// the view will be None for clickstream rows.
+
+#[tauri::command]
+#[tracing::instrument(skip(state))]
+pub async fn clickstream_bulk_search_volume(
+    state: State<'_, AppState>,
+    keywords: Vec<String>,
+    location_code: u32,
+    language_code: String,
+    use_cache: bool,
+) -> Result<BulkVolumeView> {
+    let mut seen = HashSet::new();
+    let mut cleaned: Vec<String> = keywords
+        .into_iter()
+        .map(|k| k.trim().to_owned())
+        .filter(|k| !k.is_empty() && seen.insert(k.clone()))
+        .collect();
+    if cleaned.is_empty() {
+        return Err(AppError::Validation("at least one keyword required".into()));
+    }
+    if cleaned.len() > BULK_VOLUME_MAX {
+        cleaned.truncate(BULK_VOLUME_MAX);
+    }
+    let estimated_usd = cost::estimate(&CostAction::ClickstreamBulkSearchVolume {
+        count: cleaned.len() as u32,
+    });
+    let endpoint = endpoints::KEYWORDS_CLICKSTREAM_BULK_SEARCH_VOLUME;
+    let mut sorted_keywords = cleaned.clone();
+    sorted_keywords.sort();
+    let cache_params = serde_json::json!({
+        "keywords": sorted_keywords,
+        "location_code": location_code,
+        "language_code": &language_code,
+    });
+    if let CachedOutcome::Hit { mut view, fetched_at } = cached::lookup::<BulkVolumeView>(
+        state.store.clone(), endpoint, &cache_params, cache::ttl_long(), use_cache,
+    ).await? {
+        view.from_cache = true;
+        view.fetched_at = Some(fetched_at);
+        view.cost_usd = 0.0;
+        view.estimated_usd = estimated_usd;
+        return Ok(view);
+    }
+    let api = state.api.clone();
+    let cleaned_for_call = cleaned.clone();
+    let request_size = cleaned.len() as i64;
+    let resp = run_with_ledger(
+        state.store.clone(),
+        endpoint,
+        Mode::Live,
+        estimated_usd,
+        request_size,
+        move || async move {
+            let r = api
+                .clickstream_bulk_search_volume_live(&cleaned_for_call, location_code, &language_code)
+                .await?;
+            let cost = r.cost;
+            Ok((r, cost))
+        },
+    )
+    .await?;
+    let view = BulkVolumeView {
+        items: resp
+            .items
+            .into_iter()
+            .map(|it| BulkVolumeItem {
+                keyword: it.keyword,
+                search_volume: it.search_volume,
+                competition: None,
+                competition_level: None,
+                cpc: None,
+            })
+            .collect(),
+        cost_usd: resp.cost,
+        estimated_usd,
+        from_cache: false,
+        fetched_at: None,
+    };
+    cached::store_view(state.store.clone(), endpoint, &cache_params, &view, resp.cost).await?;
+    Ok(view)
+}
+
 // ---------- True Keyword Gap ----------
 //
 // Orchestration on top of labs_ranked_keywords. Runs the call for both

--- a/apps/dataforseo-app/src-tauri/src/domain/cost.rs
+++ b/apps/dataforseo-app/src-tauri/src/domain/cost.rs
@@ -129,6 +129,11 @@ pub enum CostAction {
     /// App Data — Google Play / App Store searches and reviews. 0.002 USD
     /// per request regardless of result count.
     AppData,
+    /// Clickstream Bulk Search Volume · 0.0006 USD per keyword. Six times
+    /// the price of Labs Bulk Search Volume but sourced from DataForSEO's
+    /// clickstream panel, which tends to be more accurate on long-tail
+    /// terms than Google Ads estimates.
+    ClickstreamBulkSearchVolume { count: u32 },
 }
 
 pub fn estimate(action: &CostAction) -> f64 {
@@ -214,6 +219,7 @@ pub fn estimate(action: &CostAction) -> f64 {
         DomainAnalyticsAggregationTechnologies => 0.001,
         AppendixFree => 0.0,
         AppData => 0.002,
+        ClickstreamBulkSearchVolume { count } => (*count as f64).max(1.0) * 0.0006,
     }
 }
 
@@ -337,6 +343,19 @@ mod tests {
         // .max(1.0) keeps the cost preview from going to 0 before the
         // user has typed anything.
         assert!((cost - 0.0001).abs() < 1e-9);
+    }
+
+    #[test]
+    fn clickstream_bulk_volume_charges_per_keyword() {
+        let cost = estimate(&CostAction::ClickstreamBulkSearchVolume { count: 1000 });
+        assert!((cost - 0.6).abs() < 1e-9);
+    }
+
+    #[test]
+    fn clickstream_is_six_times_labs_bulk_volume() {
+        let labs = estimate(&CostAction::LabsBulkSearchVolume { count: 500 });
+        let cs = estimate(&CostAction::ClickstreamBulkSearchVolume { count: 500 });
+        assert!((cs / labs - 6.0).abs() < 1e-9);
     }
 
     #[test]

--- a/apps/dataforseo-app/src-tauri/src/domain/endpoints.rs
+++ b/apps/dataforseo-app/src-tauri/src/domain/endpoints.rs
@@ -93,3 +93,6 @@ pub const APP_DATA_GOOGLE_PLAY_SEARCHES: &str = "app_data.google.app_searches";
 pub const APP_DATA_GOOGLE_PLAY_REVIEWS: &str = "app_data.google.app_reviews";
 pub const APP_DATA_APPLE_SEARCHES: &str = "app_data.apple.app_searches";
 pub const APP_DATA_APPLE_REVIEWS: &str = "app_data.apple.app_reviews";
+
+pub const KEYWORDS_CLICKSTREAM_BULK_SEARCH_VOLUME: &str =
+    "keywords_data.clickstream.bulk_search_volume";

--- a/apps/dataforseo-app/src-tauri/src/lib.rs
+++ b/apps/dataforseo-app/src-tauri/src/lib.rs
@@ -106,6 +106,7 @@ pub fn run() {
             commands::keywords::labs_competitors_domain,
             commands::keywords::labs_domain_intersection,
             commands::keywords::labs_bulk_search_volume,
+            commands::keywords::clickstream_bulk_search_volume,
             commands::keywords::keyword_gap,
             commands::serp::serp_live,
             commands::serp::serp_ads_live,

--- a/apps/dataforseo-app/src-tauri/tests/api_tests.rs
+++ b/apps/dataforseo-app/src-tauri/tests/api_tests.rs
@@ -205,6 +205,32 @@ async fn keywords_search_volume_parses_items() {
 }
 
 #[tokio::test]
+async fn clickstream_bulk_search_volume_parses_items() {
+    let server = MockServer::start().await;
+    let body = dfs_response_items(0.0006, serde_json::json!([
+        { "keyword": "seo tools", "search_volume": 18400 },
+        { "keyword": "rank tracker", "search_volume": 3300 }
+    ]));
+    Mock::given(method("POST"))
+        .and(path("/v3/keywords_data/clickstream_data/bulk_search_volume/live"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .mount(&server)
+        .await;
+
+    let api = client(server.uri());
+    let keywords = vec!["seo tools".to_string(), "rank tracker".to_string()];
+    let resp = api
+        .clickstream_bulk_search_volume_live(&keywords, 2840, "en")
+        .await
+        .expect("clickstream call should succeed");
+
+    assert_eq!(resp.items.len(), 2);
+    assert_eq!(resp.items[0].keyword, "seo tools");
+    assert_eq!(resp.items[0].search_volume, Some(18400));
+    assert!((resp.cost - 0.0006).abs() < 1e-9, "cost mismatch");
+}
+
+#[tokio::test]
 async fn keywords_search_volume_empty_keywords_returns_empty() {
     let api = client("http://localhost:9999".into()); // never reached
     let resp = api

--- a/apps/dataforseo-app/src/i18n/de.json
+++ b/apps/dataforseo-app/src/i18n/de.json
@@ -97,10 +97,14 @@
       "description": "Günstige Bulk-Volumenabfrage via DataForSEO Labs — 0,0001 USD pro Keyword (≈ 0,10 USD für 1000 Keywords vs. ~7,50 USD via Google Ads). Bis zu {{max}} Keywords pro Anfrage.",
       "keywordsLabel": "Keywords ({{count}}/{{max}})",
       "perKeyword": "0,0001 USD pro Keyword",
+      "perKeywordClickstream": "0,0006 USD pro Keyword",
       "cached30d": "30 Tage gecacht",
       "loadedCached": "{{count}} Keywords geladen (gecacht, 0,00 $)",
       "loaded": "{{count}} Keywords geladen ({{cost}})",
-      "empty": "Keywords oben einfügen und auf Abfragen klicken."
+      "empty": "Keywords oben einfügen und auf Abfragen klicken.",
+      "sourceLabel": "Volumen-Quelle",
+      "sourceLabs": "Labs (günstig)",
+      "sourceClickstream": "Clickstream (Long-Tail-genau)"
     },
     "overview": {
       "description": "Umfassende Single-Call-Abfrage — Volumen, KD, CPC, Suchintention und SERP-Features auf einmal. Ersetzt 4–5 einzelne Labs-Aufrufe. 0,0125 USD pro Abfrage, 7 Tage gecacht.",

--- a/apps/dataforseo-app/src/i18n/en.json
+++ b/apps/dataforseo-app/src/i18n/en.json
@@ -97,10 +97,14 @@
       "description": "Cheap bulk volume lookup via DataForSEO Labs — 0.0001 USD per keyword (≈ 0.10 USD for 1000 kw, vs ~7.50 USD via Google Ads). Up to {{max}} keywords per request.",
       "keywordsLabel": "Keywords ({{count}}/{{max}})",
       "perKeyword": "0.0001 USD per keyword",
+      "perKeywordClickstream": "0.0006 USD per keyword",
       "cached30d": "Cached for 30 days",
       "loadedCached": "Loaded {{count}} keywords (cached, $0.00)",
       "loaded": "Loaded {{count}} keywords ({{cost}})",
-      "empty": "Paste keywords above and click Lookup."
+      "empty": "Paste keywords above and click Lookup.",
+      "sourceLabel": "Volume source",
+      "sourceLabs": "Labs (cheap)",
+      "sourceClickstream": "Clickstream (long-tail accurate)"
     },
     "overview": {
       "description": "Comprehensive single-call keyword lookup — volume, KD, CPC, search intent, and SERP feature signals all at once. Replaces 4-5 separate Labs calls. 0.0125 USD per lookup, cached for 7 days.",

--- a/apps/dataforseo-app/src/lib/cost.ts
+++ b/apps/dataforseo-app/src/lib/cost.ts
@@ -53,7 +53,8 @@ export type CostAction =
   | { kind: "DomainAnalyticsDomainsByTechnology" }
   | { kind: "DomainAnalyticsAggregationTechnologies" }
   | { kind: "AppendixFree" }
-  | { kind: "AppData" };
+  | { kind: "AppData" }
+  | { kind: "ClickstreamBulkSearchVolume"; count: number };
 
 export function estimate(action: CostAction): number {
   switch (action.kind) {
@@ -160,5 +161,7 @@ export function estimate(action: CostAction): number {
       return 0.001;
     case "AppData":
       return 0.002;
+    case "ClickstreamBulkSearchVolume":
+      return Math.max(1, action.count) * 0.0006;
   }
 }

--- a/apps/dataforseo-app/src/lib/tauri.ts
+++ b/apps/dataforseo-app/src/lib/tauri.ts
@@ -108,6 +108,9 @@ export const tauriApi = {
   labsBulkSearchVolume: (args: { keywords: string[]; locationCode: number; languageCode: string; useCache: boolean }) =>
     invoke<BulkVolumeView>("labs_bulk_search_volume", args),
 
+  clickstreamBulkSearchVolume: (args: { keywords: string[]; locationCode: number; languageCode: string; useCache: boolean }) =>
+    invoke<BulkVolumeView>("clickstream_bulk_search_volume", args),
+
   keywordGap: (args: { yours: string; competitor: string; locationCode: number; languageCode: string; limit: number; useCache: boolean }) =>
     invoke<KeywordGapView>("keyword_gap", args),
 

--- a/apps/dataforseo-app/src/routes/keywords/BulkVolumeTab.tsx
+++ b/apps/dataforseo-app/src/routes/keywords/BulkVolumeTab.tsx
@@ -14,14 +14,20 @@ import { tauriApi, type BulkVolumeItem, type BulkVolumeView } from "../../lib/ta
 
 const MAX_KEYWORDS = 1000;
 
-/// Cheapest per-keyword volume in the catalogue: 0.0001 USD/kw via the
-/// Labs Bulk Search Volume endpoint. ~750x cheaper than Google Ads at
-/// bulk (1000 keywords for 0.10 USD vs 75 USD), trades some long-tail
-/// accuracy. Cached for 30 days like the other Bulk endpoints.
+type VolumeSource = "labs" | "clickstream";
+
+/// Bulk per-keyword volume with a Labs (0.0001/kw, Google-Ads-derived) /
+/// Clickstream (0.0006/kw, panel-derived) source toggle. Labs is the
+/// default — ~750× cheaper than Google Ads at bulk and good enough for
+/// head terms. Clickstream is more accurate on long-tail at 6× the
+/// per-kw cost. Both responses share the same view shape so the table
+/// renders identically; clickstream rows have null competition / CPC
+/// because the panel source doesn't carry ad-auction signals.
 export default function BulkVolumeTab() {
   const { t } = useTranslation();
   const [text, setText] = useState("");
   const [busy, setBusy] = useState(false);
+  const [source, setSource] = useState<VolumeSource>("labs");
   const [view, setView] = useState<BulkVolumeView | null>(null);
 
   const keywords = useMemo(() => {
@@ -41,7 +47,11 @@ export default function BulkVolumeTab() {
     if (keywords.length === 0) return;
     setBusy(true);
     try {
-      const result = await tauriApi.labsBulkSearchVolume({
+      const call =
+        source === "clickstream"
+          ? tauriApi.clickstreamBulkSearchVolume
+          : tauriApi.labsBulkSearchVolume;
+      const result = await call({
         keywords,
         locationCode: DEFAULT_LOCATION,
         languageCode: DEFAULT_LANGUAGE,
@@ -108,14 +118,49 @@ export default function BulkVolumeTab() {
           />
         </label>
         <div className="flex flex-col gap-3">
+          <fieldset className="flex flex-col gap-1 text-xs">
+            <legend className="font-medium text-slate-700">
+              {t("keywords.bulkVolume.sourceLabel")}
+            </legend>
+            <div className="flex gap-3">
+              <label className="flex items-center gap-1.5">
+                <input
+                  type="radio"
+                  name="bulk-volume-source"
+                  value="labs"
+                  checked={source === "labs"}
+                  onChange={() => setSource("labs")}
+                  disabled={busy}
+                />
+                <span>{t("keywords.bulkVolume.sourceLabs")}</span>
+              </label>
+              <label className="flex items-center gap-1.5">
+                <input
+                  type="radio"
+                  name="bulk-volume-source"
+                  value="clickstream"
+                  checked={source === "clickstream"}
+                  onChange={() => setSource("clickstream")}
+                  disabled={busy}
+                />
+                <span>{t("keywords.bulkVolume.sourceClickstream")}</span>
+              </label>
+            </div>
+          </fieldset>
           <CostPreview
-            action={{ kind: "LabsBulkSearchVolume", count: keywords.length }}
+            action={
+              source === "clickstream"
+                ? { kind: "ClickstreamBulkSearchVolume", count: keywords.length }
+                : { kind: "LabsBulkSearchVolume", count: keywords.length }
+            }
             details={[
               t("keywords.bulkVolume.keywordsLabel", {
                 count: keywords.length,
                 max: MAX_KEYWORDS,
               }),
-              t("keywords.bulkVolume.perKeyword"),
+              source === "clickstream"
+                ? t("keywords.bulkVolume.perKeywordClickstream")
+                : t("keywords.bulkVolume.perKeyword"),
               t("keywords.bulkVolume.cached30d"),
             ]}
             disabled={busy || keywords.length === 0}


### PR DESCRIPTION
## Summary
Adds the only `🟡 next` endpoint from the catalogue: **Clickstream Bulk Search Volume** at 0.0006 USD/kw — panel-sourced volume that's typically more accurate on long-tail than Google Ads estimates, complementing the existing Labs Bulk Search Volume (0.0001 USD/kw, ad-auction-derived).

The **Bulk Volume** tab in Keywords now has a Labs / Clickstream source radio. Both responses share `BulkVolumeView` so the table renders identically; clickstream rows have null `competition` / `cpc` since the panel source doesn't carry ad-auction signals.

## Changes
- `api/keywords_data.rs` — `clickstream_bulk_search_volume_live`
- `commands/keywords.rs` — `clickstream_bulk_search_volume` command with 30-day response cache
- `domain/cost.rs` — `ClickstreamBulkSearchVolume { count }` cost variant + 2 unit tests
- `domain/endpoints.rs` — `KEYWORDS_CLICKSTREAM_BULK_SEARCH_VOLUME` ledger key
- `lib/cost.ts` + `lib/tauri.ts` — frontend mirrors
- `routes/keywords/BulkVolumeTab.tsx` — Labs/Clickstream source toggle, source-aware cost preview
- `i18n/en.json` + `i18n/de.json` — source labels + per-kw cost copy
- `tests/api_tests.rs` — wiremock fixture for the new client method
- `docs/DATAFORSEO_API_ENDPOINTS.md` — marks `🟡 next` → `✅ done`

## Test plan
- [x] Frontend `pnpm tsc --noEmit` clean
- [x] Frontend `pnpm test` — 107/107 pass
- [ ] CI: `cargo check` + `cargo test` (local disk filled before completion; logic mirrors `labs_bulk_search_volume` exactly)
- [ ] Manual: paste 10 keywords into Bulk Volume tab, toggle source, confirm cost preview updates (Labs `$0.0010` → Clickstream `$0.0060`)
- [ ] Manual: confirm clickstream rows show `—` for Competition/Level/CPC columns
- [ ] Manual: confirm 30-day cache hit on second identical lookup with same source

https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR

---
_Generated by [Claude Code](https://claude.ai/code/session_016KKr3pGXiJctGgbcqaNgMR)_